### PR TITLE
EditArtViewModel settings update persist after activity death

### DIFF
--- a/app/src/main/java/com/activityartapp/data/cache/ActivitiesCache.kt
+++ b/app/src/main/java/com/activityartapp/data/cache/ActivitiesCache.kt
@@ -6,6 +6,6 @@ import com.activityartapp.domain.models.Activity
  * Global Singleton cache data-layer which is populated during the first data load and
  * then never again.
  */
-object ActivitiesCache {
+class ActivitiesCache {
     val cachedActivitiesByYear: MutableMap<Int, List<Activity>> = mutableMapOf()
 }

--- a/app/src/main/java/com/activityartapp/di/AppModule.kt
+++ b/app/src/main/java/com/activityartapp/di/AppModule.kt
@@ -49,7 +49,7 @@ object AppModule {
 
     @Singleton
     @Provides
-    fun provideActivitiesCache() = ActivitiesCache
+    fun provideActivitiesCache() = ActivitiesCache()
 
     @Provides
     fun providesGetAthleteFromLocalUseCase(athleteDatabase: AthleteDatabase) =

--- a/app/src/main/java/com/activityartapp/presentation/MainActivity.kt
+++ b/app/src/main/java/com/activityartapp/presentation/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Text
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -20,6 +21,7 @@ import com.activityartapp.domain.models.Activity
 import com.activityartapp.presentation.MainDestination.*
 import com.activityartapp.presentation.MainViewEvent.LoadAuthentication
 import com.activityartapp.presentation.MainViewState.Authenticated
+import com.activityartapp.presentation.common.ScreenBackground
 import com.activityartapp.presentation.ui.theme.AthleteApiArtTheme
 import com.activityartapp.util.NavArgSpecification.*
 import com.activityartapp.util.ParcelableActivity
@@ -56,46 +58,60 @@ class MainActivity : ComponentActivity(), Router<MainDestination> {
         // Push event to ViewModel to determine authentication
         val intentUri = intent.data.also { intent.data = null }
         super.onCreate(savedInstanceState)
+        var debugTest = false
         (YEAR_EARLIEST..YEAR_NOW).forEach { year ->
             savedInstanceState?.getParcelableArray("$CACHED_ACTIVITIES_KEY$year")?.mapNotNull {
                 it as? (ParcelableActivity)
             }?.let {
                 activitiesCache.cachedActivitiesByYear[year] = it
+                //debugTest = true
             }
         }
-        // Install Splash Screen before content is setContent
-        val splashScreen = installSplashScreen()
-        setContent {
-            AthleteApiArtTheme {
-                val viewModel: MainViewModel = hiltViewModel()
+        if (debugTest) {
+            setContent {
+                ScreenBackground {
+                    (YEAR_EARLIEST..YEAR_NOW).forEach { year ->
+                        val activities = activitiesCache.cachedActivitiesByYear[year]
+                        Text("year: $year, activities ${activities?.size}")
 
-                viewModel.apply {
-                    /** Set splash screen to on while loading authentication **/
-                    /** Set splash screen to on while loading authentication **/
-                    splashScreen.setKeepOnScreenCondition {
-                        viewState.value == null
                     }
-                    /** Push event to [MainViewModel] to determine authentication **/
-                    LaunchedEffect(key1 = intentUri) {
-                        println("Intent uri is $intentUri")
-                        onEvent(LoadAuthentication(intentUri))
-                    }
-                    /** Set global nav controller for [routeTo] **/
-                    navController = rememberAnimatedNavController()
+                }
+            }
+        } else {
+            // Install Splash Screen before content is setContent
+            val splashScreen = installSplashScreen()
+            setContent {
+                AthleteApiArtTheme {
+                    val viewModel: MainViewModel = hiltViewModel()
 
-
-                    viewState.collectAsState().value?.let {
-                        val startScreen = if (it is Authenticated) {
-                            Welcome.route
-                        } else {
-                            Login.route
+                    viewModel.apply {
+                        /** Set splash screen to on while loading authentication **/
+                        /** Set splash screen to on while loading authentication **/
+                        splashScreen.setKeepOnScreenCondition {
+                            viewState.value == null
                         }
-                        AthleteApiArtTheme {
-                            MainNavHost(
-                                navController = navController,
-                                startRoute = startScreen,
-                                router = this@MainActivity,
-                            )
+                        /** Push event to [MainViewModel] to determine authentication **/
+                        LaunchedEffect(key1 = intentUri) {
+                            println("Intent uri is $intentUri")
+                            onEvent(LoadAuthentication(intentUri))
+                        }
+                        /** Set global nav controller for [routeTo] **/
+                        navController = rememberAnimatedNavController()
+
+
+                        viewState.collectAsState().value?.let {
+                            val startScreen = if (it is Authenticated) {
+                                Welcome.route
+                            } else {
+                                Login.route
+                            }
+                            AthleteApiArtTheme {
+                                MainNavHost(
+                                    navController = navController,
+                                    startRoute = startScreen,
+                                    router = this@MainActivity,
+                                )
+                            }
                         }
                     }
                 }
@@ -103,13 +119,16 @@ class MainActivity : ComponentActivity(), Router<MainDestination> {
         }
     }
 
+    /** SaveInstanceState is guaranteed to be called before the Activity is killed by the OS.
+     * Herein we ensure that we maintain [activitiesCache] on subsequent relaunch of the Activity **/
     override fun onSaveInstanceState(outState: Bundle) {
-        (YEAR_EARLIEST..YEAR_NOW).forEach {
-            outState.putParcelableArray(
-                "$CACHED_ACTIVITIES_KEY$it",
-                (activitiesCache.cachedActivitiesByYear[it] ?: listOf()).parcelize()
-                    .toTypedArray()
-            )
+        (YEAR_EARLIEST..YEAR_NOW).forEach { year ->
+            (activitiesCache.cachedActivitiesByYear[year])
+                ?.parcelize()
+                ?.toTypedArray()
+                ?.let {
+                    outState.putParcelableArray("$CACHED_ACTIVITIES_KEY$year", it)
+                }
         }
         super.onSaveInstanceState(outState)
     }

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtFilterType.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtFilterType.kt
@@ -1,9 +1,13 @@
 package com.activityartapp.presentation.editArtScreen
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 /**
  * Ordinal position
  */
-enum class EditArtFilterType {
+@Parcelize
+enum class EditArtFilterType : Parcelable {
     DATE, TYPE, DISTANCE;
 
     inline fun forEachNextFilterType(action: (EditArtFilterType) -> Unit) {

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
@@ -10,9 +10,12 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.room.Ignore
 import com.activityartapp.R
 import com.activityartapp.architecture.ViewEvent
 import com.activityartapp.architecture.ViewState
+import com.activityartapp.domain.models.ResolutionListFactory
+import com.activityartapp.presentation.editArtScreen.subscreens.resize.ResolutionListFactoryImpl
 import com.activityartapp.presentation.editArtScreen.subscreens.type.EditArtTypeSection
 import com.activityartapp.presentation.editArtScreen.subscreens.type.EditArtTypeType
 import com.activityartapp.util.FontSizeType
@@ -20,8 +23,10 @@ import com.activityartapp.util.enums.FontType
 import com.activityartapp.util.enums.FontWeightType
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.PagerState
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
+import javax.inject.Inject
 
 annotation class UnixMS
 
@@ -107,62 +112,111 @@ sealed interface EditArtViewState : ViewState {
     val pagerStateWrapper: PagerStateWrapper
 
     data class Loading(
-        override val dialogNavigateUpActive: Boolean,
-        override val pagerStateWrapper: PagerStateWrapper
+        override val dialogNavigateUpActive: Boolean = false,
+        override val pagerStateWrapper: PagerStateWrapper = PagerStateWrapper(
+            pagerHeaders = EditArtHeaderType.values().toList(),
+            pagerState = PagerState(EditArtHeaderType.values().toList().size),
+            fadeLengthMs = Standby.FADE_LENGTH_MS // todo
+        )
     ) : EditArtViewState
 
     /**
-     * @param filterDateSelectedActivitiesCount How many activities are selected
-     * after applying filter for date and any other preceding filters.
-     * @param filterTypesCount How many activities are selected after applying
-     * filter for type and any other preceding filters.
+     * @param styleActivities The color of the activities on the art.
+     * @param styleBackground The color of the background of the art.
+     * @param styleFont The color of text on the art. When set to null, [styleActivities] determines
+     * the color of the text.
      */
+    @Parcelize
     data class Standby(
-        val bitmap: Bitmap?,
-        override val dialogNavigateUpActive: Boolean,
+        @IgnoredOnParcel val bitmap: Bitmap? = null,
+        @IgnoredOnParcel override val dialogNavigateUpActive: Boolean = false,
         val filterActivitiesCountDate: Int,
         val filterActivitiesCountDistance: Int,
         val filterActivitiesCountType: Int,
         val filterDateSelections: List<DateSelection>?,
         val filterDateSelectionIndex: Int,
-        val filterDistanceSelected: ClosedFloatingPointRange<Double>?,
-        val filterDistanceTotal: ClosedFloatingPointRange<Double>?,
-        val filterTypes: List<Pair<String, Boolean>>,
-        override val pagerStateWrapper: PagerStateWrapper,
-        val scrollStateFilter: ScrollState,
-        val scrollStateStyle: ScrollState,
-        val scrollStateType: ScrollState,
-        val scrollStateResize: ScrollState,
-        val sizeActual: Size,
-        val sizeResolutionList: List<Resolution>,
-        val sizeResolutionListSelectedIndex: Int,
-        val sizeCustomWidthPx: Int,
-        val sizeCustomHeightPx: Int,
-        val sizeCustomRangePx: IntRange,
-        val styleActivities: ColorWrapper,
-        val styleBackground: ColorWrapper,
-        val styleFont: ColorWrapper?, // Null when inheriting from activities
-        val styleStrokeWidthType: StrokeWidthType,
+        val filterDistanceSelectedStart: Double? = null,
+        val filterDistanceSelectedEnd: Double? = null,
+        val filterDistanceTotalStart: Double?,
+        val filterDistanceTotalEnd: Double?,
+        val filterTypes: List<Pair<String, Boolean>>?,
+        @IgnoredOnParcel override val pagerStateWrapper: PagerStateWrapper = PagerStateWrapper(
+            pagerHeaders = EditArtHeaderType.values().toList(),
+            pagerState = PagerState(EditArtHeaderType.values().toList().size),
+            fadeLengthMs = FADE_LENGTH_MS
+        ),
+        @IgnoredOnParcel val scrollStateFilter: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
+        @IgnoredOnParcel val scrollStateStyle: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
+        @IgnoredOnParcel val scrollStateType: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
+        @IgnoredOnParcel val scrollStateResize: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
+        val sizeResolutionList: List<Resolution> = ResolutionListFactoryImpl().create(),
+        val sizeResolutionListSelectedIndex: Int = INITIAL_SELECTED_RES_INDEX,
+        @IgnoredOnParcel val sizeCustomMaxPx: Int = CUSTOM_SIZE_MAXIMUM_PX,
+        @IgnoredOnParcel val sizeCustomMinPx: Int = CUSTOM_SIZE_MINIMUM_PX,
+        val styleActivities: ColorWrapper = ColorWrapper(
+            alpha = INIT_ACTIVITIES_ALPHA,
+            blue = INIT_ACTIVITIES_BLUE,
+            green = INIT_ACTIVITIES_GREEN,
+            red = INIT_ACTIVITIES_RED
+        ),
+        val styleBackground: ColorWrapper = ColorWrapper(
+            alpha = INIT_BACKGROUND_ALPHA,
+            blue = INIT_BACKGROUND_BLUE,
+            green = INIT_BACKGROUND_GREEN,
+            red = INIT_BACKGROUND_RED
+        ),
+        val styleFont: ColorWrapper? = null,
+        val styleStrokeWidthType: StrokeWidthType = INIT_STROKE_WIDTH,
         val typeActivitiesDistanceMetersSummed: Int,
-        // Todo, decide whether or not to add this back...
-        // val typeAthleteName: String,
-        val typeFontSelected: FontType,
-        val typeFontWeightSelected: FontWeightType,
-        val typeFontItalicized: Boolean,
-        val typeFontSizeSelected: FontSizeType,
-        val typeMaximumCustomTextLength: Int,
-        val typeLeftSelected: EditArtTypeType,
-        val typeLeftCustomText: String,
-        val typeCenterSelected: EditArtTypeType,
-        val typeCenterCustomText: String,
-        val typeRightSelected: EditArtTypeType,
-        val typeRightCustomText: String,
-    ) : EditArtViewState {
+        val typeFontSelected: FontType = INIT_TYPE_FONT_SELECTION,
+        val typeFontWeightSelected: FontWeightType = INIT_TYPE_FONT_WEIGHT_SELECTION,
+        val typeFontItalicized: Boolean = INIT_TYPE_IS_ITALICIZED,
+        val typeFontSizeSelected: FontSizeType = INIT_TYPE_FONT_SIZE_SELECTION,
+        @IgnoredOnParcel val typeMaximumCustomTextLength: Int = CUSTOM_TEXT_MAXIMUM_LENGTH,
+        val typeLeftSelected: EditArtTypeType = INIT_TYPE_TYPE,
+        val typeLeftCustomText: String = INIT_TYPE_CUSTOM_TEXT,
+        val typeCenterSelected: EditArtTypeType = INIT_TYPE_TYPE,
+        val typeCenterCustomText: String = INIT_TYPE_CUSTOM_TEXT,
+        val typeRightSelected: EditArtTypeType = INIT_TYPE_TYPE,
+        val typeRightCustomText: String = INIT_TYPE_CUSTOM_TEXT,
+    ) : EditArtViewState, Parcelable {
 
         companion object {
+            private const val CUSTOM_SIZE_MINIMUM_PX = 100
+            private const val CUSTOM_SIZE_MAXIMUM_PX = 12000
+            const val FADE_LENGTH_MS = 1000
+
+            private const val INITIAL_SCROLL_STATE = 0
+            private const val INITIAL_SELECTED_RES_INDEX = 0
+
+            /** Initial Style settings **/
+            private const val INIT_ACTIVITIES_ALPHA = 1f
+            private const val INIT_ACTIVITIES_BLUE = 1f
+            private const val INIT_ACTIVITIES_GREEN = 1f
+            private const val INIT_ACTIVITIES_RED = 1f
+            private const val INIT_BACKGROUND_ALPHA = 1f
+            private const val INIT_BACKGROUND_BLUE = 0f
+            private const val INIT_BACKGROUND_GREEN = 0f
+            private const val INIT_BACKGROUND_RED = 0f
+            private val INIT_STROKE_WIDTH = StrokeWidthType.MEDIUM
+
+            /** Initial Type settings **/
+            private const val CUSTOM_TEXT_MAXIMUM_LENGTH = 30
+            private const val INIT_TYPE_CUSTOM_TEXT = ""
+            private val INIT_TYPE_FONT_SELECTION = FontType.JOSEFIN_SANS
+            private val INIT_TYPE_FONT_WEIGHT_SELECTION = FontWeightType.REGULAR
+            private val INIT_TYPE_FONT_SIZE_SELECTION = FontSizeType.MEDIUM
+            private const val INIT_TYPE_IS_ITALICIZED = false
+            private val INIT_TYPE_TYPE = EditArtTypeType.NONE
+
             private const val NO_ACTIVITIES_COUNT = 0
         }
 
+        @Inject
+        @IgnoredOnParcel
+        lateinit var resolutionListFactory: ResolutionListFactory
+
+        @IgnoredOnParcel
         val atLeastOneActivitySelected = minOf(
             filterActivitiesCountDate,
             filterActivitiesCountDistance,
@@ -211,13 +265,26 @@ data class ColorWrapper(
     }
 }
 
-sealed interface DateSelection {
+
+sealed interface DateSelection : Parcelable {
+    @Parcelize
     object All : DateSelection
+
+    @Parcelize
     data class Year(val year: Int) : DateSelection
+
+    @Parcelize
     data class Custom(
-        @UnixMS val dateSelected: LongProgression?,
-        @UnixMS val dateTotal: LongProgression
-    ) : DateSelection
+        @UnixMS val dateSelectedStart: Long?,
+        @UnixMS val dateSelectedEnd: Long?,
+        @UnixMS val dateTotalStart: Long,
+        @UnixMS val dateTotalEnd: Long
+    ) : DateSelection {
+        val dateSelected: LongProgression?
+            get() = dateSelectedEnd?.let { dateSelectedStart?.rangeTo(it) }
+        val dateTotal: LongProgression
+            get() = dateTotalEnd.let { dateTotalStart.rangeTo(it) }
+    }
 }
 
 enum class StyleType(
@@ -252,7 +319,7 @@ enum class StrokeWidthType(val headerId: Int) {
 }
 
 
-sealed interface Resolution {
+sealed interface Resolution : Parcelable {
 
     val widthPx: Int
     val heightPx: Int
@@ -291,6 +358,7 @@ sealed interface Resolution {
         }
     }
 
+    @Parcelize
     data class ComputerResolution(
         override val stringResourceId: Int,
         override val origWidthPx: Int,
@@ -307,6 +375,7 @@ sealed interface Resolution {
         }
     }
 
+    @Parcelize
     data class PrintResolution(
         override val origWidthPx: Int,
         override val origHeightPx: Int,
@@ -338,17 +407,14 @@ sealed interface Resolution {
             get() = R.string.edit_art_resize_option_print
     }
 
+    @Parcelize
     data class CustomResolution(
-        val customWidthPx: Int = DEFAULT_CUSTOM_WIDTH_PX,
-        val customHeightPx: Int = DEFAULT_CUSTOM_HEIGHT_PX,
+        override val widthPx: Int = DEFAULT_CUSTOM_WIDTH_PX,
+        override val heightPx: Int = DEFAULT_CUSTOM_HEIGHT_PX,
     ) : Resolution {
 
         override val stringResourceId: Int
             get() = R.string.edit_art_resize_option_custom
-        override val widthPx: Int
-            get() = customWidthPx
-        override val heightPx: Int
-            get() = customHeightPx
 
         @Composable
         override fun displayTextResolution(): String {

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
@@ -105,8 +105,12 @@ fun EditArtViewDelegate(viewModel: EditArtViewModel) {
                                     filterActivitiesCountType,
                                     filterDateSelections,
                                     filterDateSelectionIndex,
-                                    filterDistanceSelected,
-                                    filterDistanceTotal,
+                                    filterDistanceSelectedEnd?.let {
+                                        filterDistanceSelectedStart?.rangeTo(it)
+                                    },
+                                    filterDistanceTotalEnd?.let {
+                                        filterDistanceTotalStart?.rangeTo(it)
+                                    },
                                     filterTypes,
                                     viewModel
                                 )
@@ -135,9 +139,9 @@ fun EditArtViewDelegate(viewModel: EditArtViewModel) {
                                 viewModel
                             )
                             RESIZE -> EditArtResizeScreen(
-                                sizeCustomHeightPx,
-                                sizeCustomWidthPx,
-                                sizeCustomRangePx,
+                           //     sizeCustomHeightPx,
+                            //    sizeCustomWidthPx,
+                                sizeCustomMinPx..sizeCustomMaxPx,
                                 sizeResolutionList,
                                 sizeResolutionListSelectedIndex,
                                 viewModel

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/filters/EditArtFiltersScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/filters/EditArtFiltersScreen.kt
@@ -1,20 +1,19 @@
 package com.activityartapp.presentation.editArtScreen.subscreens.filters
 
-import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.activityartapp.activityart.presentation.editArtScreen.subscreens.filters.composables.FilterSectionActivityType
 import com.activityartapp.architecture.EventReceiver
 import com.activityartapp.presentation.editArtScreen.DateSelection
 import com.activityartapp.presentation.editArtScreen.EditArtFilterType
 import com.activityartapp.presentation.editArtScreen.EditArtFilterType.*
 import com.activityartapp.presentation.editArtScreen.EditArtViewEvent
-import com.activityartapp.activityart.presentation.editArtScreen.subscreens.filters.composables.FilterSectionActivityType
 import com.activityartapp.presentation.editArtScreen.subscreens.filters.composables.FilterSectionDate
 import com.activityartapp.presentation.editArtScreen.subscreens.filters.composables.FilterSectionDistances
-import com.activityartapp.presentation.ui.theme.spacing
 
 @Composable
 fun ColumnScope.EditArtFiltersScreen(
@@ -25,7 +24,7 @@ fun ColumnScope.EditArtFiltersScreen(
     filterDateSelectionIndex: Int,
     distanceSelected: ClosedFloatingPointRange<Double>?,
     distanceTotal: ClosedFloatingPointRange<Double>?,
-    typesWithSelectedFlag: List<Pair<String, Boolean>>,
+    typesWithSelectedFlag: List<Pair<String, Boolean>>?,
     eventReceiver: EventReceiver<EditArtViewEvent>
 ) {
     EditArtFilterType.values().onEach {
@@ -37,12 +36,13 @@ fun ColumnScope.EditArtFiltersScreen(
                     dateSelectionSelectedIndex = filterDateSelectionIndex,
                     eventReceiver = eventReceiver
                 )
-            TYPE -> FilterSectionActivityType(
-                count = activitiesCountType,
-                typesWithSelectedFlag = typesWithSelectedFlag,
-                eventReceiver = eventReceiver
-            )
-            DISTANCE -> if (distanceTotal != null) {
+            TYPE -> if (typesWithSelectedFlag != null)
+                FilterSectionActivityType(
+                    count = activitiesCountType,
+                    typesWithSelectedFlag = typesWithSelectedFlag,
+                    eventReceiver = eventReceiver
+                )
+            DISTANCE -> if (distanceTotal != null && distanceTotal.start != distanceTotal.endInclusive) {
                 FilterSectionDistances(
                     count = activitiesCountDistance,
                     distanceSelected = distanceSelected,

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/resize/EditArtResizeScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/resize/EditArtResizeScreen.kt
@@ -30,8 +30,8 @@ import kotlin.math.roundToInt
 
 @Composable
 fun ColumnScope.EditArtResizeScreen(
-    customHeightPx: Int,
-    customWidthPx: Int,
+    // customHeightPx: Int,
+    //  customWidthPx: Int,
     customRangePx: IntRange,
     resolutionList: List<Resolution>,
     selectedResolutionIndex: Int,
@@ -63,7 +63,8 @@ fun ColumnScope.EditArtResizeScreen(
                                 SubheadHeavy(
                                     text = stringResource(
                                         R.string.edit_art_resize_pixels_width,
-                                        customWidthPx
+                                        //customWidthPx
+                                        res.widthPx
                                     ),
                                     modifier = Modifier.padding(start = spacing.small)
                                 )
@@ -71,12 +72,12 @@ fun ColumnScope.EditArtResizeScreen(
                                     eventReceiver = eventReceiver,
                                     isEnabled = isSelected,
                                     isWidth = true,
-                                    value = customWidthPx,
+                                    value = res.widthPx,
                                     valueRange = customRangePx
                                 )
                                 SubheadHeavy(
                                     text = stringResource(
-                                        R.string.edit_art_resize_pixels_height, customHeightPx
+                                        R.string.edit_art_resize_pixels_height, res.heightPx
                                     ),
                                     modifier = Modifier.padding(start = spacing.small)
                                 )
@@ -84,7 +85,7 @@ fun ColumnScope.EditArtResizeScreen(
                                     isEnabled = isSelected,
                                     isWidth = false,
                                     eventReceiver = eventReceiver,
-                                    value = customHeightPx,
+                                    value = res.heightPx,
                                     valueRange = customRangePx
                                 )
                             }

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/resize/ResolutionListFactoryImpl.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/resize/ResolutionListFactoryImpl.kt
@@ -32,6 +32,7 @@ class ResolutionListFactoryImpl : ResolutionListFactory {
             Resolution.PrintResolution(6000, 6000, 20, 20),
             Resolution.PrintResolution(6000, 9000, 20, 30),
             Resolution.PrintResolution(6000, 12000, 20, 40),
+            Resolution.CustomResolution()
         )
     }
 }


### PR DESCRIPTION
This commit updates EditArtViewModel such that after the death of MainActivity, it can restart logically and no mutations to the art are lost.