### PR TITLE
Add SORT tab to EditArtViewModel which allows user to choose sort order

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId "com.activityartapp"
         minSdk 26
         targetSdk 33
-        versionCode 4
-        versionName "1.0.3"
+        versionCode 5
+        versionName "1.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/activityartapp/di/AppModule.kt
+++ b/app/src/main/java/com/activityartapp/di/AppModule.kt
@@ -135,9 +135,10 @@ object AppModule {
     fun provideResolutionListFactory(): ResolutionListFactory = ResolutionListFactoryImpl()
 
     @Provides
-    fun provideActivityFilterUtils(timeUtils: TimeUtils) = ActivityFilterUtils(
-        timeUtils
-    )
+    fun provideActivityFilterUtils(timeUtils: TimeUtils) = ActivityFilterUtils(timeUtils)
+
+    @Provides
+    fun provideActivitySortUtils(timeUtils: TimeUtils) = ActivitySortUtils(timeUtils)
 
     @Provides
     fun provideImageSizeUtils() = ImageSizeUtils()
@@ -152,8 +153,11 @@ object AppModule {
     fun provideGson() = Gson()
 
     @Provides
-    fun provideVisualizationUtils(@ApplicationContext appContext: Context) =
-        VisualizationUtils(appContext)
+    fun provideVisualizationUtils(
+        activitySortUtils: ActivitySortUtils,
+        @ApplicationContext appContext: Context
+    ) =
+        VisualizationUtils(appContext, activitySortUtils)
 
     @Provides
     fun provideFileRepository(@ApplicationContext appContext: Context): FileRepository =

--- a/app/src/main/java/com/activityartapp/presentation/MainActivity.kt
+++ b/app/src/main/java/com/activityartapp/presentation/MainActivity.kt
@@ -177,6 +177,8 @@ class MainActivity : ComponentActivity(), Router<MainDestination> {
                         FilterDistanceMoreThanMeters to filterDistanceMoreThanMeters.toString(),
                         SizeHeightPx to sizeHeightPx.toString(),
                         SizeWidthPx to sizeWidthPx.toString(),
+                        SortType to sortType.toString(),
+                        SortDirectionType to sortDirectionType.toString(),
                         StrokeWidth to strokeWidthType.toString(),
                         TextLeft to (textLeft ?: ""),
                         TextCenter to (textCenter ?: ""),

--- a/app/src/main/java/com/activityartapp/presentation/MainModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/MainModels.kt
@@ -6,6 +6,8 @@ import com.activityartapp.architecture.ViewEvent
 import com.activityartapp.architecture.ViewState
 import com.activityartapp.presentation.editArtScreen.StrokeWidthType
 import com.activityartapp.presentation.errorScreen.ErrorScreenType
+import com.activityartapp.util.enums.EditArtSortDirectionType
+import com.activityartapp.util.enums.EditArtSortType
 import com.activityartapp.util.enums.FontSizeType
 
 sealed interface MainViewState : ViewState {
@@ -41,6 +43,8 @@ sealed interface MainDestination : Destination {
         val filterDistanceMoreThanMeters: Int,
         val sizeHeightPx: Int,
         val sizeWidthPx: Int,
+        val sortType: EditArtSortType,
+        val sortDirectionType: EditArtSortDirectionType,
         val strokeWidthType: StrokeWidthType,
         val textLeft: String?,
         val textCenter: String?,

--- a/app/src/main/java/com/activityartapp/presentation/MainNavHost.kt
+++ b/app/src/main/java/com/activityartapp/presentation/MainNavHost.kt
@@ -78,6 +78,8 @@ fun MainNavHost(
                 FilterDistanceMoreThanMeters,
                 SizeHeightPx,
                 SizeWidthPx,
+                SortDirectionType,
+                SortType,
                 StrokeWidth,
                 TextLeft,
                 TextCenter,

--- a/app/src/main/java/com/activityartapp/presentation/common/type/SubheadHeavy.kt
+++ b/app/src/main/java/com/activityartapp/presentation/common/type/SubheadHeavy.kt
@@ -19,7 +19,7 @@ fun SubheadHeavy(
 ) {
     Text(
         text = text,
-        textAlign = TextAlign.Center,
+        textAlign = textAlign,
         color = textColor ?: colorResource(id = R.color.light_text_secondary),
         style = MaterialTheme.typography.subtitle2,
         modifier = modifier

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtHeaderType.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtHeaderType.kt
@@ -31,6 +31,11 @@ enum class EditArtHeaderType(
         R.string.buttons_type_cd,
         Icons.Default.TextFields
     ),
+    SORT(
+        R.string.buttons_sort_uppercase,
+        R.string.buttons_sort_cd,
+        Icons.Default.Sort
+    ),
     RESIZE(
         R.string.buttons_resize_uppercase,
         R.string.buttons_style_cd,

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
@@ -17,9 +17,7 @@ import com.activityartapp.domain.models.ResolutionListFactory
 import com.activityartapp.presentation.editArtScreen.subscreens.resize.ResolutionListFactoryImpl
 import com.activityartapp.presentation.editArtScreen.subscreens.type.EditArtTypeSection
 import com.activityartapp.presentation.editArtScreen.subscreens.type.EditArtTypeType
-import com.activityartapp.util.enums.FontSizeType
-import com.activityartapp.util.enums.FontType
-import com.activityartapp.util.enums.FontWeightType
+import com.activityartapp.util.enums.*
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.PagerState
 import kotlinx.parcelize.IgnoredOnParcel
@@ -82,6 +80,8 @@ sealed interface EditArtViewEvent : ViewEvent {
         data class SizeChanged(val changedIndex: Int) : ArtMutatingEvent
         object SizeCustomChangeDone : ArtMutatingEvent
         data class SizeRotated(val rotatedIndex: Int) : ArtMutatingEvent
+        data class SortDirectionChanged(val changedTo: EditArtSortDirectionType) : ArtMutatingEvent
+        data class SortTypeChanged(val changedTo: EditArtSortType) : ArtMutatingEvent
         data class StyleColorFontUseCustomChanged(val useCustom: Boolean) : ArtMutatingEvent
         data class StylesColorChanged(
             val styleType: StyleType,
@@ -153,10 +153,13 @@ sealed interface EditArtViewState : ViewState {
         @IgnoredOnParcel val scrollStateStyle: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
         @IgnoredOnParcel val scrollStateType: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
         @IgnoredOnParcel val scrollStateResize: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
+        @IgnoredOnParcel val scrollStateSort: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
         val sizeResolutionList: List<Resolution> = ResolutionListFactoryImpl().create(),
         val sizeResolutionListSelectedIndex: Int = INITIAL_SELECTED_RES_INDEX,
         @IgnoredOnParcel val sizeCustomMaxPx: Int = CUSTOM_SIZE_MAXIMUM_PX,
         @IgnoredOnParcel val sizeCustomMinPx: Int = CUSTOM_SIZE_MINIMUM_PX,
+        val sortTypeSelected: EditArtSortType = EditArtSortType.DATE,
+        val sortDirectionTypeSelected: EditArtSortDirectionType = EditArtSortDirectionType.ASCENDING,
         val styleActivities: ColorWrapper = ColorWrapper(
             alpha = INIT_ACTIVITIES_ALPHA,
             blue = INIT_ACTIVITIES_BLUE,

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
@@ -23,11 +23,14 @@ import com.activityartapp.presentation.editArtScreen.composables.EditArtDialogNa
 import com.activityartapp.presentation.editArtScreen.subscreens.filters.EditArtFiltersScreen
 import com.activityartapp.presentation.editArtScreen.subscreens.preview.EditArtPreview
 import com.activityartapp.presentation.editArtScreen.subscreens.resize.EditArtResizeScreen
+import com.activityartapp.presentation.editArtScreen.subscreens.sort.EditArtSortScreen
 import com.activityartapp.presentation.editArtScreen.subscreens.style.EditArtStyleViewDelegate
 import com.activityartapp.presentation.editArtScreen.subscreens.type.EditArtTypeScreen
 import com.activityartapp.presentation.ui.theme.White
 import com.activityartapp.presentation.ui.theme.spacing
 import com.activityartapp.util.classes.YearMonthDay
+import com.activityartapp.util.enums.EditArtSortDirectionType
+import com.activityartapp.util.enums.EditArtSortType
 import com.google.accompanist.pager.ExperimentalPagerApi
 
 private const val DISABLED_ALPHA = 0.5f
@@ -88,6 +91,7 @@ fun EditArtViewDelegate(viewModel: EditArtViewModel) {
                             FILTERS -> scrollStateFilter
                             STYLE -> scrollStateStyle
                             TYPE -> scrollStateType
+                            SORT -> scrollStateSort
                             RESIZE -> scrollStateResize
                             else -> null
                         },
@@ -138,9 +142,14 @@ fun EditArtViewDelegate(viewModel: EditArtViewModel) {
                                 typeRightSelected,
                                 viewModel
                             )
+                            SORT -> EditArtSortScreen(
+                                sortTypeSelected = sortTypeSelected,
+                                sortDirectionSelected = sortDirectionTypeSelected,
+                                eventReceiver = viewModel
+                            )
                             RESIZE -> EditArtResizeScreen(
-                           //     sizeCustomHeightPx,
-                            //    sizeCustomWidthPx,
+                                //     sizeCustomHeightPx,
+                                //    sizeCustomWidthPx,
                                 sizeCustomMinPx..sizeCustomMaxPx,
                                 sizeResolutionList,
                                 sizeResolutionListSelectedIndex,

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
@@ -234,6 +234,8 @@ class EditArtViewModel @Inject constructor(
             is SizeChanged -> onSizeChanged(event)
             is SizeCustomChangeDone -> onSizeCustomChangeDone()
             is SizeRotated -> onSizeRotated(event)
+            is SortDirectionChanged -> onSortDirectionChanged(event)
+            is SortTypeChanged -> onSortTypeChanged(event)
             is StylesColorChanged -> onStylesColorChanged(event)
             is StyleColorFontUseCustomChanged -> onStyleColorFontUseCustomChanged(event)
             is StylesStrokeWidthChanged -> onStylesStrokeWidthChanged(event)
@@ -382,6 +384,8 @@ class EditArtViewModel @Inject constructor(
                             ?: Int.MIN_VALUE,
                         sizeHeightPx = targetSize.heightPx,
                         sizeWidthPx = targetSize.widthPx,
+                        sortType = sortTypeSelected,
+                        sortDirectionType = sortDirectionTypeSelected,
                         strokeWidthType = styleStrokeWidthType,
                         textLeft = LEFT.text,
                         textCenter = CENTER.text,
@@ -439,6 +443,14 @@ class EditArtViewModel @Inject constructor(
                     }
             )
         }.push()
+    }
+
+    private fun onSortDirectionChanged(event: SortDirectionChanged) {
+        copyLastState { copy(sortDirectionTypeSelected = event.changedTo) }.push()
+    }
+
+    private fun onSortTypeChanged(event: SortTypeChanged) {
+        copyLastState { copy(sortTypeSelected = event.changedTo) }.push()
     }
 
     private fun onStylesColorChanged(event: StylesColorChanged) {
@@ -557,6 +569,8 @@ class EditArtViewModel @Inject constructor(
                         italicized = typeFontItalicized
                     ),
                     fontSize = typeFontSizeSelected,
+                    sortType = sortTypeSelected,
+                    sortDirectionType = sortDirectionTypeSelected,
                     textLeft = LEFT.text,
                     textCenter = CENTER.text,
                     textRight = RIGHT.text

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/sort/EditArtSortScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/sort/EditArtSortScreen.kt
@@ -1,0 +1,85 @@
+package com.activityartapp.presentation.editArtScreen.subscreens.sort
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.RadioButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.activityartapp.R
+import com.activityartapp.architecture.EventReceiver
+import com.activityartapp.presentation.common.type.Body
+import com.activityartapp.presentation.common.type.Subhead
+import com.activityartapp.presentation.common.type.SubheadHeavy
+import com.activityartapp.presentation.editArtScreen.EditArtViewEvent
+import com.activityartapp.presentation.editArtScreen.composables.Section
+import com.activityartapp.presentation.ui.theme.spacing
+import com.activityartapp.util.enums.EditArtSortDirectionType
+import com.activityartapp.util.enums.EditArtSortType
+
+
+@Composable
+fun ColumnScope.EditArtSortScreen(
+    sortTypeSelected: EditArtSortType,
+    sortDirectionSelected: EditArtSortDirectionType,
+    eventReceiver: EventReceiver<EditArtViewEvent>
+) {
+    Section(
+        header = stringResource(R.string.edit_art_sort_header),
+        description = stringResource(R.string.edit_art_sort_description)
+    ) {
+        EditArtSortType.values().forEach { sortType ->
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(spacing.medium),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RadioButton(
+                    selected = sortType == sortTypeSelected,
+                    onClick = {
+                        eventReceiver.onEvent(
+                            EditArtViewEvent.ArtMutatingEvent.SortTypeChanged(
+                                sortType
+                            )
+                        )
+                    }
+                )
+                Subhead(text = stringResource(sortType.strRes))
+            }
+        }
+    }
+    Section(
+        header = stringResource(R.string.edit_art_sort_direction_header),
+        description = stringResource(R.string.edit_art_sort_direction_description)
+    ) {
+        EditArtSortDirectionType.values().forEach { sortDirectionType ->
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(spacing.medium),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RadioButton(
+                    selected = sortDirectionType == sortDirectionSelected,
+                    onClick = {
+                        eventReceiver.onEvent(
+                            EditArtViewEvent.ArtMutatingEvent.SortDirectionChanged(
+                                sortDirectionType
+                            )
+                        )
+                    }
+                )
+                Column(verticalArrangement = Arrangement.spacedBy(spacing.small)) {
+                    Subhead(text = stringResource(sortDirectionType.headerStrRes))
+                    SubheadHeavy(
+                        text = stringResource(
+                            id = sortDirectionType.description(
+                                sortTypeSelected
+                            )
+                        ),
+                        textAlign = TextAlign.Start
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/activityartapp/presentation/saveArtScreen/SaveArtViewModel.kt
+++ b/app/src/main/java/com/activityartapp/presentation/saveArtScreen/SaveArtViewModel.kt
@@ -16,6 +16,8 @@ import com.activityartapp.presentation.saveArtScreen.SaveArtViewState.*
 import com.activityartapp.presentation.saveArtScreen.SaveArtViewEvent.*
 import com.activityartapp.util.*
 import com.activityartapp.util.NavArgSpecification.*
+import com.activityartapp.util.enums.EditArtSortDirectionType
+import com.activityartapp.util.enums.EditArtSortType
 import com.activityartapp.util.enums.FontSizeType
 import com.google.gson.Gson
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -55,6 +57,8 @@ class SaveArtViewModel @Inject constructor(
     private val filterDistanceMoreThanMeters = FilterDistanceMoreThanMeters.rawArg(ssh).toInt()
     private val sizeHeightPx = SizeHeightPx.rawArg(ssh).toInt()
     private val sizeWidthPx = SizeWidthPx.rawArg(ssh).toInt()
+    private val sortDirectionType = EditArtSortDirectionType.valueOf(SortDirectionType.rawArg(ssh))
+    private val sortType = EditArtSortType.valueOf(SortType.rawArg(ssh))
     private val strokeWidthType = StrokeWidthType.valueOf(StrokeWidth.rawArg(ssh))
     private val textLeft = TextLeft.rawArg(ssh).takeIf { it.isNotBlank() }
     private val textCenter = TextCenter.rawArg(ssh).takeIf { it.isNotBlank() }
@@ -155,6 +159,8 @@ class SaveArtViewModel @Inject constructor(
                         PREVIEW_BITMAP_MAX_SIZE_HEIGHT_PX
                     )
                 ),
+                sortType = sortType,
+                sortDirectionType = sortDirectionType,
                 strokeWidth = strokeWidthType,
                 textLeft = textLeft,
                 textCenter = textCenter,

--- a/app/src/main/java/com/activityartapp/util/ActivitySortUtils.kt
+++ b/app/src/main/java/com/activityartapp/util/ActivitySortUtils.kt
@@ -1,0 +1,32 @@
+package com.activityartapp.util
+
+import com.activityartapp.domain.models.Activity
+import com.activityartapp.util.enums.EditArtSortDirectionType
+import com.activityartapp.util.enums.EditArtSortType
+import javax.inject.Inject
+
+class ActivitySortUtils @Inject constructor(
+    private val timeUtils: TimeUtils
+) {
+    fun sortActivities(
+        activities: List<Activity>,
+        sortType: EditArtSortType,
+        sortDirection: EditArtSortDirectionType
+    ): List<Activity> {
+        return activities
+            .sortedWith(compareBy {
+                when (sortType) {
+                    EditArtSortType.DATE -> timeUtils.iso8601StringToUnixSecond(it.iso8601LocalDate)
+                    EditArtSortType.DISTANCE -> it.distance
+                    EditArtSortType.TYPE -> it.type
+                }
+            })
+            .run {
+                if (sortDirection == EditArtSortDirectionType.ASCENDING) {
+                    this
+                } else {
+                    asReversed()
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/activityartapp/util/NavArgSpecification.kt
+++ b/app/src/main/java/com/activityartapp/util/NavArgSpecification.kt
@@ -21,6 +21,8 @@ sealed interface NavArgSpecification {
         private const val FILTER_DISTANCE_MORE_THAN_KEY = "filterDistanceMoreThanMeters"
         private const val SIZE_HEIGHT_KEY = "sizeHeight"
         private const val SIZE_WIDTH_KEY = "sizeWidth"
+        private const val SORT_TYPE_KEY = "sortType"
+        private const val SORT_DIRECTION_TYPE_KEY = "sortDirectionType"
         private const val STROKE_WIDTH_KEY = "strokeWidth"
         private const val TEXT_LEFT_KEY = "textLeft"
         private const val TEXT_CENTER_KEY = "textCenter"
@@ -100,6 +102,14 @@ sealed interface NavArgSpecification {
 
     object SizeWidthPx : NavArgSpecification {
         override val name = SIZE_WIDTH_KEY
+    }
+
+    object SortType : NavArgSpecification {
+        override val name: String = SORT_TYPE_KEY
+    }
+
+    object SortDirectionType : NavArgSpecification {
+        override val name: String = SORT_DIRECTION_TYPE_KEY
     }
 
     object TextLeft : NavArgSpecification {

--- a/app/src/main/java/com/activityartapp/util/VisualizationUtils.kt
+++ b/app/src/main/java/com/activityartapp/util/VisualizationUtils.kt
@@ -6,6 +6,8 @@ import android.util.Size
 import androidx.annotation.Px
 import com.activityartapp.domain.models.Activity
 import com.activityartapp.presentation.editArtScreen.StrokeWidthType
+import com.activityartapp.util.enums.EditArtSortDirectionType
+import com.activityartapp.util.enums.EditArtSortType
 import com.activityartapp.util.enums.FontSizeType
 import com.google.maps.android.PolyUtil
 import javax.inject.Inject
@@ -13,7 +15,10 @@ import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.sqrt
 
-class VisualizationUtils @Inject constructor(private val context: Context) {
+class VisualizationUtils @Inject constructor(
+    private val context: Context,
+    private val activitySortUtils: ActivitySortUtils
+) {
 
     companion object {
         private const val ACTIVITY_SIZE_REDUCE_FRACTION = 0.85f
@@ -31,6 +36,8 @@ class VisualizationUtils @Inject constructor(private val context: Context) {
         bitmapSize: Size,
         fontAssetPath: String,
         fontSize: FontSizeType,
+        sortType: EditArtSortType,
+        sortDirectionType: EditArtSortDirectionType,
         strokeWidth: StrokeWidthType,
         @Px paddingFraction: Float = 0.1f,
         textLeft: String? = null,
@@ -119,7 +126,12 @@ class VisualizationUtils @Inject constructor(private val context: Context) {
                     }
 
                     val finalRowOffset = (activitySize * remainder) / 2f
-                    activities.forEachIndexed { index, activity ->
+                    val sortedActivities = activitySortUtils.sortActivities(
+                        activities,
+                        sortType,
+                        sortDirectionType
+                    )
+                    sortedActivities.forEachIndexed { index, activity ->
                         // 0 % 1 = 0
                         // 0 * 606 = 0
 

--- a/app/src/main/java/com/activityartapp/util/constants/StringConstants.kt
+++ b/app/src/main/java/com/activityartapp/util/constants/StringConstants.kt
@@ -2,5 +2,5 @@ package com.activityartapp.util.constants
 
 object StringConstants {
     const val BASE_URL = "https://www.strava.com/"
-    const val APP_VERSION = "1.0.3"
+    const val APP_VERSION = "1.1.0"
 }

--- a/app/src/main/java/com/activityartapp/util/enums/EditArtSortDirectionType.kt
+++ b/app/src/main/java/com/activityartapp/util/enums/EditArtSortDirectionType.kt
@@ -1,0 +1,30 @@
+package com.activityartapp.util.enums
+
+import androidx.annotation.StringRes
+import com.activityartapp.R
+
+enum class EditArtSortDirectionType(@StringRes val headerStrRes: Int) {
+    ASCENDING(R.string.edit_art_sort_direction_ascending_header) {
+        @StringRes
+        override fun description(sortType: EditArtSortType): Int {
+            return when (sortType) {
+                EditArtSortType.DATE -> R.string.edit_art_sort_direction_ascending_description_date
+                EditArtSortType.DISTANCE -> R.string.edit_art_sort_direction_ascending_description_distance
+                EditArtSortType.TYPE -> R.string.edit_art_sort_direction_ascending_description_type
+            }
+        }
+    },
+    DESCENDING(R.string.edit_art_sort_direction_descending_header) {
+        @StringRes
+        override fun description(sortType: EditArtSortType): Int {
+            return when (sortType) {
+                EditArtSortType.DATE -> R.string.edit_art_sort_direction_descending_description_date
+                EditArtSortType.DISTANCE -> R.string.edit_art_sort_direction_descending_description_distance
+                EditArtSortType.TYPE -> R.string.edit_art_sort_direction_descending_description_type
+            }
+        }
+    };
+
+    @StringRes
+    abstract fun description(sortType: EditArtSortType): Int
+}

--- a/app/src/main/java/com/activityartapp/util/enums/EditArtSortType.kt
+++ b/app/src/main/java/com/activityartapp/util/enums/EditArtSortType.kt
@@ -1,0 +1,10 @@
+package com.activityartapp.util.enums
+
+import androidx.annotation.StringRes
+import com.activityartapp.R
+
+enum class EditArtSortType(@StringRes val strRes: Int) {
+    DATE(R.string.edit_art_sort_type_date),
+    DISTANCE(R.string.edit_art_sort_type_distance),
+    TYPE(R.string.edit_art_sort_type_type);
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,6 +125,8 @@
     <string name="buttons_style_cd">Style Art</string>
     <string name="buttons_type_uppercase">TYPE</string>
     <string name="buttons_type_cd">Typography</string>
+    <string name="buttons_sort_uppercase">SORT</string>
+    <string name="buttons_sort_cd">Sort By</string>
     <string name="buttons_resize_uppercase">RESIZE</string>
     <string name="buttons_resize_cd">Resize Art</string>
 
@@ -209,6 +211,22 @@
 
     <string name="edit_art_type_size_header">Font Size</string>
     <string name="edit_art_type_size_description">How large should any text be?</string>
+
+    <string name="edit_art_sort_header">Sort By</string>
+    <string name="edit_art_sort_description">Which property of your activities should they be ordered by?</string>
+    <string name="edit_art_sort_type_date">Date</string>
+    <string name="edit_art_sort_type_distance">Distance</string>
+    <string name="edit_art_sort_type_type">Type</string>
+    <string name="edit_art_sort_direction_header">Sort Direction</string>
+    <string name="edit_art_sort_direction_description">Which way should activities be ordered with the \"sort by\" property?</string>
+    <string name="edit_art_sort_direction_ascending_header">Ascending</string>
+    <string name="edit_art_sort_direction_ascending_description_date">Oldest to newest</string>
+    <string name="edit_art_sort_direction_ascending_description_distance">Shortest to longest</string>
+    <string name="edit_art_sort_direction_ascending_description_type">A to Z - for example, you would see any rides before walks</string>
+    <string name="edit_art_sort_direction_descending_header">Descending</string>
+    <string name="edit_art_sort_direction_descending_description_date">Newest to oldest</string>
+    <string name="edit_art_sort_direction_descending_description_distance">Longest to shortest</string>
+    <string name="edit_art_sort_direction_descending_description_type">Z to A - for example, you would see any walks before rides</string>
 
     <string name="edit_art_resize_header">Resize Art</string>
     <string name="edit_art_resize_description">

--- a/app/src/test/java/com/activityartapp/util/ActivitySortUtilsTest.kt
+++ b/app/src/test/java/com/activityartapp/util/ActivitySortUtilsTest.kt
@@ -1,0 +1,241 @@
+package com.activityartapp.util
+
+import com.activityartapp.domain.models.Activity
+import com.activityartapp.util.enums.EditArtSortDirectionType
+import com.activityartapp.util.enums.EditArtSortType
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ActivitySortUtilsTest {
+
+    companion object {
+        private const val CONSTANT_ATHLETE_ID = 0L
+        private const val CONSTANT_AVERAGE_SPEED = 0.0
+        private const val CONSTANT_GEAR_ID = "0"
+        private const val CONSTANT_ID = 0L
+        private const val CONSTANT_KUDOS_COUNT = 0
+        private const val CONSTANT_LOCATION_CITY = ""
+        private const val CONSTANT_LOCATION_COUNTRY = ""
+        private const val CONSTANT_LOCATION_STATE = ""
+        private const val CONSTANT_MAX_SPEED = 0.0
+        private const val CONSTANT_MOVING_TIME = 0
+        private const val CONSTANT_NAME = ""
+        private const val CONSTANT_SUFFER_SCORE = 0
+        private const val CONSTANT_SUMMARY_POLYLINE = ""
+
+        private const val ACTIVITY_ONE_DISTANCE = 5.0
+        private const val ACTIVITY_ONE_ISO8601_LOCAL_DATE = "2018-05-02T05:15:09Z"
+        private const val ACTIVITY_ONE_TYPE = "Walk"
+        private const val ACTIVITY_TWO_DISTANCE = 10.0
+        private const val ACTIVITY_TWO_ISO8601_LOCAL_DATE = "2019-05-02T05:15:09Z"
+        private const val ACTIVITY_TWO_TYPE = "Ride"
+        private const val ACTIVITY_THREE_DISTANCE = 15.0
+        private const val ACTIVITY_THREE_ISO8601_LOCAL_DATE = "2020-05-02T05:15:09Z"
+        private const val ACTIVITY_THREE_TYPE = "Kayaking"
+        private const val ACTIVITY_FOUR_DISTANCE = 5.0
+        private const val ACTIVITY_FOUR_ISO8601_LOCAL_DATE = "2022-05-02T05:15:09Z"
+        private const val ACTIVITY_FOUR_TYPE = "Ride"
+    }
+
+    private lateinit var activitySortUtils: ActivitySortUtils
+    private lateinit var activityOne: Activity
+    private lateinit var activityTwo: Activity
+    private lateinit var activityThree: Activity
+    private lateinit var activityFour: Activity
+    private lateinit var activitiesIncludingOnlyActivityOne: List<Activity>
+    private lateinit var activities: List<Activity>
+
+    @Before
+    fun setUp() {
+        activitySortUtils = ActivitySortUtils(TimeUtils())
+        activityOne = object : Activity {
+            override val athleteId: Long = CONSTANT_ATHLETE_ID
+            override val averageSpeed: Double = CONSTANT_AVERAGE_SPEED
+            override val distance: Double = ACTIVITY_ONE_DISTANCE
+            override val gearId: String = CONSTANT_GEAR_ID
+            override val id: Long = CONSTANT_ID
+            override val iso8601LocalDate: String = ACTIVITY_ONE_ISO8601_LOCAL_DATE
+            override val kudosCount: Int = CONSTANT_KUDOS_COUNT
+            override val locationCity: String = CONSTANT_LOCATION_CITY
+            override val locationCountry: String = CONSTANT_LOCATION_COUNTRY
+            override val locationState: String = CONSTANT_LOCATION_STATE
+            override val maxSpeed: Double = CONSTANT_MAX_SPEED
+            override val movingTime: Int = CONSTANT_MOVING_TIME
+            override val name: String = CONSTANT_NAME
+            override val sufferScore: Int = CONSTANT_SUFFER_SCORE
+            override val summaryPolyline: String = CONSTANT_SUMMARY_POLYLINE
+            override val type: String = ACTIVITY_ONE_TYPE
+        }
+        activityTwo = object : Activity {
+            override val athleteId: Long = CONSTANT_ATHLETE_ID
+            override val averageSpeed: Double = CONSTANT_AVERAGE_SPEED
+            override val distance: Double = ACTIVITY_TWO_DISTANCE
+            override val gearId: String = CONSTANT_GEAR_ID
+            override val id: Long = CONSTANT_ID
+            override val iso8601LocalDate: String = ACTIVITY_TWO_ISO8601_LOCAL_DATE
+            override val kudosCount: Int = CONSTANT_KUDOS_COUNT
+            override val locationCity: String = CONSTANT_LOCATION_CITY
+            override val locationCountry: String = CONSTANT_LOCATION_COUNTRY
+            override val locationState: String = CONSTANT_LOCATION_STATE
+            override val maxSpeed: Double = CONSTANT_MAX_SPEED
+            override val movingTime: Int = CONSTANT_MOVING_TIME
+            override val name: String = CONSTANT_NAME
+            override val sufferScore: Int = CONSTANT_SUFFER_SCORE
+            override val summaryPolyline: String = CONSTANT_SUMMARY_POLYLINE
+            override val type: String = ACTIVITY_TWO_TYPE
+        }
+        activityThree = object : Activity {
+            override val athleteId: Long = CONSTANT_ATHLETE_ID
+            override val averageSpeed: Double = CONSTANT_AVERAGE_SPEED
+            override val distance: Double = ACTIVITY_THREE_DISTANCE
+            override val gearId: String = CONSTANT_GEAR_ID
+            override val id: Long = CONSTANT_ID
+            override val iso8601LocalDate: String = ACTIVITY_THREE_ISO8601_LOCAL_DATE
+            override val kudosCount: Int = CONSTANT_KUDOS_COUNT
+            override val locationCity: String = CONSTANT_LOCATION_CITY
+            override val locationCountry: String = CONSTANT_LOCATION_COUNTRY
+            override val locationState: String = CONSTANT_LOCATION_STATE
+            override val maxSpeed: Double = CONSTANT_MAX_SPEED
+            override val movingTime: Int = CONSTANT_MOVING_TIME
+            override val name: String = CONSTANT_NAME
+            override val sufferScore: Int = CONSTANT_SUFFER_SCORE
+            override val summaryPolyline: String = CONSTANT_SUMMARY_POLYLINE
+            override val type: String = ACTIVITY_THREE_TYPE
+        }
+        activityFour = object : Activity {
+            override val athleteId: Long = CONSTANT_ATHLETE_ID
+            override val averageSpeed: Double = CONSTANT_AVERAGE_SPEED
+            override val distance: Double = ACTIVITY_FOUR_DISTANCE
+            override val gearId: String = CONSTANT_GEAR_ID
+            override val id: Long = CONSTANT_ID
+            override val iso8601LocalDate: String = ACTIVITY_FOUR_ISO8601_LOCAL_DATE
+            override val kudosCount: Int = CONSTANT_KUDOS_COUNT
+            override val locationCity: String = CONSTANT_LOCATION_CITY
+            override val locationCountry: String = CONSTANT_LOCATION_COUNTRY
+            override val locationState: String = CONSTANT_LOCATION_STATE
+            override val maxSpeed: Double = CONSTANT_MAX_SPEED
+            override val movingTime: Int = CONSTANT_MOVING_TIME
+            override val name: String = CONSTANT_NAME
+            override val sufferScore: Int = CONSTANT_SUFFER_SCORE
+            override val summaryPolyline: String = CONSTANT_SUMMARY_POLYLINE
+            override val type: String = ACTIVITY_FOUR_TYPE
+        }
+        activitiesIncludingOnlyActivityOne = listOf(activityOne)
+        activities = listOf(activityOne, activityThree, activityTwo, activityFour)
+    }
+
+    /** Test [ActivitySortUtils.sortActivities] **/
+    @Test
+    fun `Sorting an empty list on each sort type and direction returns an empty list`() {
+        val emptyList: List<Activity> = emptyList()
+        EditArtSortType.values().forEach { type ->
+            EditArtSortDirectionType.values().forEach { direction ->
+                assertTrue(
+                    activitySortUtils.sortActivities(
+                        emptyList,
+                        type,
+                        direction
+                    ) == emptyList<List<Activity>>()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Sorting a list of a single activity on each sort type and direction returns a list of that activity`() {
+        EditArtSortType.values().forEach { type ->
+            EditArtSortDirectionType.values().forEach { direction ->
+                assertTrue(
+                    activitySortUtils.sortActivities(
+                        activitiesIncludingOnlyActivityOne,
+                        type,
+                        direction
+                    ) == listOf(activityOne)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `Sorting a list on date ascending returns correct order`() {
+        val ordered = activitySortUtils.sortActivities(
+            activities,
+            EditArtSortType.DATE,
+            EditArtSortDirectionType.ASCENDING
+        )
+        assert(ordered[0] == activityOne)
+        assert(ordered[1] == activityTwo)
+        assert(ordered[2] == activityThree)
+        assert(ordered[3] == activityFour)
+    }
+
+    @Test
+    fun `Sorting a list on date descending returns correct order`() {
+        val ordered = activitySortUtils.sortActivities(
+            activities,
+            EditArtSortType.DATE,
+            EditArtSortDirectionType.DESCENDING
+        )
+        assert(ordered[3] == activityOne)
+        assert(ordered[2] == activityTwo)
+        assert(ordered[1] == activityThree)
+        assert(ordered[0] == activityFour)
+    }
+
+    @Test
+    fun `Sorting a list on distance ascending returns correct order and is stable`() {
+        val ordered = activitySortUtils.sortActivities(
+            activities,
+            EditArtSortType.DISTANCE,
+            EditArtSortDirectionType.ASCENDING
+        )
+        /** One before four is preserving relative order when the attribute is the same **/
+        assert(ordered[0] == activityOne)
+        assert(ordered[1] == activityFour)
+        assert(ordered[2] == activityTwo)
+        assert(ordered[3] == activityThree)
+    }
+
+    @Test
+    fun `Sorting a list on distance descending returns correct order and is stable`() {
+        val ordered = activitySortUtils.sortActivities(
+            activities,
+            EditArtSortType.DISTANCE,
+            EditArtSortDirectionType.DESCENDING
+        )
+        /** One after four is preserving relative order when the attribute is the same **/
+        assert(ordered[3] == activityOne)
+        assert(ordered[2] == activityFour)
+        assert(ordered[1] == activityTwo)
+        assert(ordered[0] == activityThree)
+    }
+
+    @Test
+    fun `Sorting a list on type ascending returns correct order and is stable`() {
+        val ordered = activitySortUtils.sortActivities(
+            activities,
+            EditArtSortType.TYPE,
+            EditArtSortDirectionType.ASCENDING
+        )
+        /** Two before four is preserving relative order when the attribute is the same **/
+        assert(ordered[0] == activityThree)
+        assert(ordered[1] == activityTwo)
+        assert(ordered[2] == activityFour)
+        assert(ordered[3] == activityOne)
+    }
+
+    @Test
+    fun `Sorting a list on type descending returns correct order and is stable`() {
+        val ordered = activitySortUtils.sortActivities(
+            activities,
+            EditArtSortType.TYPE,
+            EditArtSortDirectionType.DESCENDING
+        )
+        /** Four before two is preserving relative order when the attribute is the same **/
+        assert(ordered[3] == activityThree)
+        assert(ordered[2] == activityTwo)
+        assert(ordered[1] == activityFour)
+        assert(ordered[0] == activityOne)
+    }
+}


### PR DESCRIPTION
* This commit adds a sort tab to EditArtViewModel where an athlete may choose from distance, date, and type sort types.
* Once a sort type has been selected, the athlete may also choose whether to sort ascending or descending.
* Unit tests are added to cover `ActivitySortUtils`, a new utility class added to handle this.