### PR TITLE
Change custom resolution event logic to include the index that was changed

### DIFF
--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
@@ -149,7 +149,6 @@ fun EditArtViewDelegate(viewModel: EditArtViewModel) {
                                 eventReceiver = viewModel
                             )
                             RESIZE -> EditArtResizeScreen(
-                                sizeCustomMinPx..sizeCustomMaxPx,
                                 sizeResolutionList,
                                 sizeResolutionListSelectedIndex,
                                 viewModel

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/resize/EditArtResizeScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/resize/EditArtResizeScreen.kt
@@ -21,11 +21,9 @@ import com.activityartapp.presentation.editArtScreen.composables.TextFieldSlider
 import com.activityartapp.presentation.editArtScreen.composables.TextFieldSliders
 import com.activityartapp.presentation.ui.theme.spacing
 import com.activityartapp.util.ext.toFloatRange
-import kotlin.math.roundToInt
 
 @Composable
 fun EditArtResizeScreen(
-    customRangePx: IntRange,
     resolutionList: List<Resolution>,
     selectedResolutionIndex: Int,
     eventReceiver: EventReceiver<EditArtViewEvent>
@@ -51,75 +49,76 @@ fun EditArtResizeScreen(
                                 )
                             }
                         },
-                    content = (res as? Resolution.CustomResolution)
-                        ?.let {
-                            {
-                                TextFieldSliders(
-                                    specifications = listOf(
-                                        TextFieldSliderSpecification(
-                                            pendingChangesMessage = it.pendingWidth?.let {
-                                                stringResource(R.string.edit_art_resize_custom_pending_change_prompt)
-                                            },
-                                            keyboardType = KeyboardType.Number,
-                                            textFieldLabel = stringResource(R.string.edit_art_resize_pixels_width),
-                                            textFieldValue = it.pendingWidth
-                                                ?: it.widthPx.toString(),
-                                            sliderValue = it.widthPx.toFloat(),
-                                            sliderRange = customRangePx.toFloatRange(),
-                                            onSliderChanged = {
-                                                eventReceiver.onEvent(
-                                                    SizeCustomChanged.WidthChanged(
-                                                        it.toInt()
-                                                    )
-                                                )
-                                            },
-                                            onTextFieldChanged = { str ->
-                                                eventReceiver.onEvent(
-                                                    EditArtViewEvent.SizeCustomPendingChanged.WidthChanged(
-                                                        changedTo = str
-                                                    )
-                                                )
-                                            },
-                                            onTextFieldDone = {
-                                                eventReceiver.onEvent(
-                                                    SizeCustomPendingChangeConfirmed
-                                                )
-                                            }
-                                        ),
-                                        TextFieldSliderSpecification(
-                                            pendingChangesMessage = it.pendingHeight?.let {
-                                                stringResource(R.string.edit_art_resize_custom_pending_change_prompt)
-                                            },
-                                            keyboardType = KeyboardType.Number,
-                                            textFieldLabel = stringResource(R.string.edit_art_resize_pixels_height),
-                                            textFieldValue = it.pendingHeight
-                                                ?: it.heightPx.toString(),
-                                            sliderValue = it.heightPx.toFloat(),
-                                            sliderRange = customRangePx.toFloatRange(),
-                                            onSliderChanged = {
-                                                eventReceiver.onEvent(
-                                                    SizeCustomChanged.HeightChanged(
-                                                        it.toInt()
-                                                    )
-                                                )
-                                            },
-                                            onTextFieldChanged = { str ->
-                                                eventReceiver.onEvent(
-                                                    EditArtViewEvent.SizeCustomPendingChanged.HeightChanged(
-                                                        changedTo = str
-                                                    )
-                                                )
-                                            },
-                                            onTextFieldDone = {
-                                                eventReceiver.onEvent(
-                                                    SizeCustomPendingChangeConfirmed
-                                                )
-                                            }
-                                        )
-                                    )
+                    content = (res as? Resolution.CustomResolution)?.let {
+                        {
+                            val range = it.sizeRangePx.toFloatRange()
+                            val onTextFieldDone = {
+                                eventReceiver.onEvent(
+                                    SizeCustomPendingChangeConfirmed(customIndex = index)
                                 )
                             }
-                        },
+                            TextFieldSliders(
+                                specifications = listOf(
+                                    TextFieldSliderSpecification(
+                                        pendingChangesMessage = it.pendingWidth?.let {
+                                            stringResource(R.string.edit_art_resize_custom_pending_change_prompt)
+                                        },
+                                        keyboardType = KeyboardType.Number,
+                                        textFieldLabel = stringResource(R.string.edit_art_resize_pixels_width),
+                                        textFieldValue = it.pendingWidth
+                                            ?: it.widthPx.toString(),
+                                        sliderValue = it.widthPx.toFloat(),
+                                        sliderRange = range,
+                                        onSliderChanged = {
+                                            eventReceiver.onEvent(
+                                                SizeCustomChanged(
+                                                    customIndex = index,
+                                                    changedToPx = it.toInt(),
+                                                    heightChanged = false
+                                                )
+                                            )
+                                        },
+                                        onTextFieldChanged = { str ->
+                                            eventReceiver.onEvent(
+                                                EditArtViewEvent.SizeCustomPendingChanged.WidthChanged(
+                                                    changedTo = str
+                                                )
+                                            )
+                                        },
+                                        onTextFieldDone = onTextFieldDone
+                                    ),
+                                    TextFieldSliderSpecification(
+                                        pendingChangesMessage = it.pendingHeight?.let {
+                                            stringResource(R.string.edit_art_resize_custom_pending_change_prompt)
+                                        },
+                                        keyboardType = KeyboardType.Number,
+                                        textFieldLabel = stringResource(R.string.edit_art_resize_pixels_height),
+                                        textFieldValue = it.pendingHeight
+                                            ?: it.heightPx.toString(),
+                                        sliderValue = it.heightPx.toFloat(),
+                                        sliderRange = range,
+                                        onSliderChanged = {
+                                            eventReceiver.onEvent(
+                                                SizeCustomChanged(
+                                                    customIndex = index,
+                                                    changedToPx = it.toInt(),
+                                                    heightChanged = true
+                                                )
+                                            )
+                                        },
+                                        onTextFieldChanged = { str ->
+                                            eventReceiver.onEvent(
+                                                EditArtViewEvent.SizeCustomPendingChanged.HeightChanged(
+                                                    changedTo = str
+                                                )
+                                            )
+                                        },
+                                        onTextFieldDone = onTextFieldDone
+                                    )
+                                )
+                            )
+                        }
+                    },
                     onActionButtonPressed = { eventReceiver.onEvent(SizeRotated(index)) },
                     isSelected = isSelected,
                     text = res.displayTextResolution(),

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/resize/ResolutionListFactoryImpl.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/resize/ResolutionListFactoryImpl.kt
@@ -6,6 +6,13 @@ import com.activityartapp.presentation.editArtScreen.Resolution
 
 class ResolutionListFactoryImpl : ResolutionListFactory {
 
+    companion object {
+        private const val SIZE_CUSTOM_INITIAL_WIDTH_PX = 1920
+        private const val SIZE_CUSTOM_INITIAL_HEIGHT_PX = 1080
+        private const val SIZE_CUSTOM_MAXIMUM_PX = 12000
+        private const val SIZE_CUSTOM_MINIMUM_PX = 100
+    }
+
     override fun create(): MutableList<Resolution> {
         return mutableListOf(
             Resolution.ComputerResolution(
@@ -32,7 +39,12 @@ class ResolutionListFactoryImpl : ResolutionListFactory {
             Resolution.PrintResolution(6000, 6000, 20, 20),
             Resolution.PrintResolution(6000, 9000, 20, 30),
             Resolution.PrintResolution(6000, 12000, 20, 40),
-            Resolution.CustomResolution()
+            Resolution.CustomResolution(
+                widthPx = SIZE_CUSTOM_INITIAL_WIDTH_PX,
+                heightPx = SIZE_CUSTOM_INITIAL_HEIGHT_PX,
+                sizeMaximumPx = SIZE_CUSTOM_MAXIMUM_PX,
+                sizeMinimumPx = SIZE_CUSTOM_MINIMUM_PX
+            )
         )
     }
 }


### PR DESCRIPTION
* This commit changes the custom resolution event logic to include the index that was changed, whereas previously the first index that was a custom resolution object was used. This should be more readable.