### PR TITLE
Inputting into custom text works when custom not selected then automatically selects.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId "com.activityartapp"
         minSdk 26
         targetSdk 33
-        versionCode 15
-        versionName "1.4.0"
+        versionCode 16
+        versionName "1.4.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
@@ -713,9 +713,18 @@ class EditArtViewModel @Inject constructor(
             }
         copyLastState {
             when (event.section) {
-                LEFT -> copy(typeLeftCustomText = newText ?: typeLeftCustomText)
-                CENTER -> copy(typeCenterCustomText = newText ?: typeCenterCustomText)
-                RIGHT -> copy(typeRightCustomText = newText ?: typeRightCustomText)
+                LEFT -> copy(
+                    typeLeftCustomText = newText ?: typeLeftCustomText,
+                    typeLeftSelected = CUSTOM
+                )
+                CENTER -> copy(
+                    typeCenterCustomText = newText ?: typeCenterCustomText,
+                    typeCenterSelected = CUSTOM
+                )
+                RIGHT -> copy(
+                    typeRightCustomText = newText ?: typeRightCustomText,
+                    typeRightSelected = CUSTOM
+                )
             }
         }.push()
     }

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/type/EditArtTypeScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/type/EditArtTypeScreen.kt
@@ -86,11 +86,6 @@ fun EditArtTypeScreen(
                                     ),
                                     singleLine = true,
                                     maxLines = 1,
-                                    enabled = EditArtTypeType.CUSTOM == when (section) {
-                                        EditArtTypeSection.LEFT -> selectedEditArtTypeTypeLeft
-                                        EditArtTypeSection.CENTER -> selectedEditArtTypeTypeCenter
-                                        EditArtTypeSection.RIGHT -> selectedEditArtTypeTypeRight
-                                    },
                                     modifier = Modifier.sizeIn(maxWidth = 254.dp)
                                 )
                                 Text(


### PR DESCRIPTION
* This commit fixes a stale design choice I wanted to remove where the custom text cannot be used until it is selected.