### PR TITLE
Increase performance of EditArtViewState by limiting recomposition

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,7 +59,7 @@ android {
 }
 
 dependencies {
-    def composeBom = platform('androidx.compose:compose-bom:2022.12.00')
+    def composeBom = platform('androidx.compose:compose-bom:2023.01.00')
     def firebaseBom = platform('com.google.firebase:firebase-bom:31.1.1')
     implementation composeBom
     implementation firebaseBom
@@ -84,6 +84,7 @@ dependencies {
     implementation 'androidx.compose.material:material-icons-extended'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1'
     implementation 'androidx.compose.runtime:runtime-livedata'
+    implementation 'androidx.compose.runtime:runtime'
 
     // Serialization
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId "com.activityartapp"
         minSdk 26
         targetSdk 33
-        versionCode 16
-        versionName "1.4.1"
+        versionCode 17
+        versionName "1.4.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
@@ -154,7 +154,6 @@ sealed interface EditArtViewEvent : ViewEvent {
 sealed interface EditArtViewState : ViewState {
 
     companion object {
-        private const val FADE_LENGTH_MS = 1000
         const val MAX_GRADIENT_BG_COLORS = 7
         const val MIN_GRADIENT_BG_COLORS = 2
     }
@@ -163,62 +162,54 @@ sealed interface EditArtViewState : ViewState {
     val pagerStateWrapper: PagerStateWrapper
 
     data class Loading(
-        override val dialogActive: State<EditArtDialog> = mutableStateOf(EditArtDialog.None), // todo this is tmp
-        override val pagerStateWrapper: PagerStateWrapper = PagerStateWrapper(
-            pagerHeaders = EditArtHeaderType.values().toList(),
-            pagerState = PagerState(EditArtHeaderType.values().toList().size),
-            fadeLengthMs = FADE_LENGTH_MS // todo
-        )
+        override val dialogActive: State<EditArtDialog>,
+        override val pagerStateWrapper: PagerStateWrapper
     ) : EditArtViewState
 
     data class Standby(
-       val bitmap: State<Bitmap?>,
-       override val dialogActive: State<EditArtDialog>,
-       val filterActivitiesCountDate: State<Int>,
-       val filterActivitiesCountDistance: State<Int>,
-       val filterActivitiesCountType: State<Int>,
-       val filterDateSelections: SnapshotStateList<DateSelection>,
-       val filterDateSelectionIndex: State<Int>,
-       val filterDistanceSelectedStart: State<Double?>,
-       val filterDistanceSelectedEnd: State<Double?>,
-       val filterDistanceTotalStart: State<Double?>,
-       val filterDistanceTotalEnd: State<Double?>,
-       val filterDistancePendingChangeStart: State<String?>,
-       val filterDistancePendingChangeEnd: State<String?>,
-       val filterTypes: SnapshotStateMap<SportType, Boolean>,
-       override val pagerStateWrapper: PagerStateWrapper = PagerStateWrapper(
-           pagerHeaders = EditArtHeaderType.values().toList(),
-           pagerState = PagerState(EditArtHeaderType.values().toList().size),
-            fadeLengthMs = FADE_LENGTH_MS
-        ),
-       val listStateFilter: LazyListState = LazyListState(),
-       val listStateStyle: LazyListState = LazyListState(),
-       val scrollStateType: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
-       val scrollStateResize: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
-       val scrollStateSort: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
-       val sizeResolutionList: SnapshotStateList<Resolution>,
-       val sizeResolutionListSelectedIndex: State<Int>,
-       val sortTypeSelected: State<EditArtSortType>,
-       val sortDirectionTypeSelected: State<EditArtSortDirectionType>,
-       val styleActivities: State<ColorWrapper>,
-       val styleBackgroundList: SnapshotStateList<ColorWrapper>,
-       val styleBackgroundAngleType: State<AngleType>,
-       val styleBackgroundGradientColorCount: State<Int>,
-       val styleBackgroundType: State<BackgroundType>,
-       val styleFont: State<ColorWrapper?>,
-       val styleStrokeWidthType: State<StrokeWidthType>,
-       val typeActivitiesDistanceMetersSummed: State<Int>,
-       val typeFontSelected: State<FontType>,
-       val typeFontWeightSelected: State<FontWeightType>,
-       val typeFontItalicized: State<Boolean>,
-       val typeFontSizeSelected: State<FontSizeType>,
-       val typeMaximumCustomTextLength: Int,
-       val typeLeftSelected: State<EditArtTypeType>,
-       val typeLeftCustomText: State<String>,
-       val typeCenterSelected: State<EditArtTypeType>,
-       val typeCenterCustomText: State<String>,
-       val typeRightSelected: State<EditArtTypeType>,
-       val typeRightCustomText: State<String>,
+        val bitmap: State<Bitmap?>,
+        override val dialogActive: State<EditArtDialog>,
+        val filterActivitiesCountDate: State<Int>,
+        val filterActivitiesCountDistance: State<Int>,
+        val filterActivitiesCountType: State<Int>,
+        val filterDateSelections: SnapshotStateList<DateSelection>,
+        val filterDateSelectionIndex: State<Int>,
+        val filterDistanceSelectedStart: State<Double?>,
+        val filterDistanceSelectedEnd: State<Double?>,
+        val filterDistanceTotalStart: State<Double?>,
+        val filterDistanceTotalEnd: State<Double?>,
+        val filterDistancePendingChangeStart: State<String?>,
+        val filterDistancePendingChangeEnd: State<String?>,
+        val filterTypes: SnapshotStateMap<SportType, Boolean>,
+        override val pagerStateWrapper: PagerStateWrapper,
+        val listStateFilter: LazyListState = LazyListState(),
+        val listStateStyle: LazyListState = LazyListState(),
+        val scrollStateType: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
+        val scrollStateResize: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
+        val scrollStateSort: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
+        val sizeResolutionList: SnapshotStateList<Resolution>,
+        val sizeResolutionListSelectedIndex: State<Int>,
+        val sortTypeSelected: State<EditArtSortType>,
+        val sortDirectionTypeSelected: State<EditArtSortDirectionType>,
+        val styleActivities: State<ColorWrapper>,
+        val styleBackgroundList: SnapshotStateList<ColorWrapper>,
+        val styleBackgroundAngleType: State<AngleType>,
+        val styleBackgroundGradientColorCount: State<Int>,
+        val styleBackgroundType: State<BackgroundType>,
+        val styleFont: State<ColorWrapper?>,
+        val styleStrokeWidthType: State<StrokeWidthType>,
+        val typeActivitiesDistanceMetersSummed: State<Int>,
+        val typeFontSelected: State<FontType>,
+        val typeFontWeightSelected: State<FontWeightType>,
+        val typeFontItalicized: State<Boolean>,
+        val typeFontSizeSelected: State<FontSizeType>,
+        val typeMaximumCustomTextLength: Int,
+        val typeLeftSelected: State<EditArtTypeType>,
+        val typeLeftCustomText: State<String>,
+        val typeCenterSelected: State<EditArtTypeType>,
+        val typeCenterCustomText: State<String>,
+        val typeRightSelected: State<EditArtTypeType>,
+        val typeRightCustomText: State<String>,
     ) : EditArtViewState {
 
         companion object {
@@ -226,8 +217,9 @@ sealed interface EditArtViewState : ViewState {
         }
 
         @Inject
-        @IgnoredOnParcel
         lateinit var resolutionListFactory: ResolutionListFactory
+
+
     }
 }
 
@@ -246,11 +238,13 @@ data class FilterStateWrapper(
 ) : Parcelable
 
 @Parcelize
+// https://developer.android.com/reference/kotlin/androidx/compose/runtime/Immutable
+@Immutable
 data class ColorWrapper(
-    var alpha: Float,
-    var blue: Float,
-    var green: Float,
-    var red: Float,
+    val alpha: Float,
+    val blue: Float,
+    val green: Float,
+    val red: Float,
     @IgnoredOnParcel val pendingAlpha: String? = null,
     @IgnoredOnParcel val pendingBlue: String? = null,
     @IgnoredOnParcel val pendingGreen: String? = null,

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
@@ -171,7 +171,6 @@ sealed interface EditArtViewState : ViewState {
         )
     ) : EditArtViewState
 
-   // @Parcelize
     data class Standby(
        val bitmap: State<Bitmap?>,
        override val dialogActive: State<EditArtDialog>,
@@ -187,17 +186,17 @@ sealed interface EditArtViewState : ViewState {
        val filterDistancePendingChangeStart: State<String?>,
        val filterDistancePendingChangeEnd: State<String?>,
        val filterTypes: SnapshotStateMap<SportType, Boolean>,
-       @IgnoredOnParcel override val pagerStateWrapper: PagerStateWrapper = PagerStateWrapper(
+       override val pagerStateWrapper: PagerStateWrapper = PagerStateWrapper(
            pagerHeaders = EditArtHeaderType.values().toList(),
            pagerState = PagerState(EditArtHeaderType.values().toList().size),
             fadeLengthMs = FADE_LENGTH_MS
         ),
-       @IgnoredOnParcel val listStateFilter: LazyListState = LazyListState(),
-       @IgnoredOnParcel val listStateStyle: LazyListState = LazyListState(),
-       @IgnoredOnParcel val scrollStateType: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
-       @IgnoredOnParcel val scrollStateResize: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
-       @IgnoredOnParcel val scrollStateSort: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
-       val sizeResolutionList: List<Resolution>,
+       val listStateFilter: LazyListState = LazyListState(),
+       val listStateStyle: LazyListState = LazyListState(),
+       val scrollStateType: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
+       val scrollStateResize: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
+       val scrollStateSort: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
+       val sizeResolutionList: SnapshotStateList<Resolution>,
        val sizeResolutionListSelectedIndex: State<Int>,
        val sortTypeSelected: State<EditArtSortType>,
        val sortDirectionTypeSelected: State<EditArtSortDirectionType>,
@@ -213,7 +212,7 @@ sealed interface EditArtViewState : ViewState {
        val typeFontWeightSelected: State<FontWeightType>,
        val typeFontItalicized: State<Boolean>,
        val typeFontSizeSelected: State<FontSizeType>,
-       @IgnoredOnParcel val typeMaximumCustomTextLength: Int,
+       val typeMaximumCustomTextLength: Int,
        val typeLeftSelected: State<EditArtTypeType>,
        val typeLeftCustomText: State<String>,
        val typeCenterSelected: State<EditArtTypeType>,
@@ -229,31 +228,6 @@ sealed interface EditArtViewState : ViewState {
         @Inject
         @IgnoredOnParcel
         lateinit var resolutionListFactory: ResolutionListFactory
-
-        /*
-        @IgnoredOnParcel
-        val atLeastOneActivitySelected
-            get() = minOf(
-                filterActivitiesCountDate,
-                filterActivitiesCountDistance,
-                filterActivitiesCountType
-            ) != NO_ACTIVITIES_COUNT
-
-        @IgnoredOnParcel
-        val filteredTypes: List<SportType>
-            get() = filterTypes?.entries?.filter { it.value }?.map { it.key } ?: emptyList()
-
-        val filteredDistanceRangeMeters: IntRange
-            get() = (filterDistanceSelectedStart
-                ?.roundToInt()
-                ?: Int.MIN_VALUE)
-                .rangeTo(
-                    filterDistanceSelectedEnd
-                        ?.roundToInt()
-                        ?: Int.MAX_VALUE
-                )
-
-         */
     }
 }
 

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
@@ -7,7 +7,9 @@ import android.os.Parcelable
 import androidx.annotation.StringRes
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
+import androidx.compose.runtime.snapshots.SnapshotMutableState
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.res.stringResource
 import com.activityartapp.R
@@ -156,11 +158,11 @@ sealed interface EditArtViewState : ViewState {
         const val MIN_GRADIENT_BG_COLORS = 2
     }
 
-    val dialogActive: EditArtDialog
+    val dialogActive: State<EditArtDialog>
     val pagerStateWrapper: PagerStateWrapper
 
     data class Loading(
-        override val dialogActive: EditArtDialog = EditArtDialog.None,
+        override val dialogActive: State<EditArtDialog> = mutableStateOf(EditArtDialog.None), // todo this is tmp
         override val pagerStateWrapper: PagerStateWrapper = PagerStateWrapper(
             pagerHeaders = EditArtHeaderType.values().toList(),
             pagerState = PagerState(EditArtHeaderType.values().toList().size),
@@ -168,111 +170,66 @@ sealed interface EditArtViewState : ViewState {
         )
     ) : EditArtViewState
 
-    @Parcelize
+   // @Parcelize
     data class Standby(
-        @IgnoredOnParcel val bitmap: Bitmap? = null,
-        @IgnoredOnParcel override val dialogActive: EditArtDialog = EditArtDialog.None,
-        val filterActivitiesCountDate: Int = 0,
-        val filterActivitiesCountDistance: Int = 0,
-        val filterActivitiesCountType: Int = 0,
-        val filterDateSelections: List<DateSelection>? = null,
-        val filterDateSelectionIndex: Int = INIT_SELECTION_INDEX,
-        val filterDistanceSelectedStart: Double? = null,
-        val filterDistanceSelectedEnd: Double? = null,
-        val filterDistanceTotalStart: Double? = null,
-        val filterDistanceTotalEnd: Double? = null,
-        @IgnoredOnParcel val filterDistancePendingChangeStart: String? = null,
-        @IgnoredOnParcel val filterDistancePendingChangeEnd: String? = null,
-        val filterTypes: Map<SportType, Boolean>? = null,
-        @IgnoredOnParcel override val pagerStateWrapper: PagerStateWrapper = PagerStateWrapper(
-            pagerHeaders = EditArtHeaderType.values().toList(),
-            pagerState = PagerState(EditArtHeaderType.values().toList().size),
+       val bitmap: State<Bitmap?>,
+       override val dialogActive: State<EditArtDialog>,
+       val filterActivitiesCountDate: State<Int>,
+       val filterActivitiesCountDistance: State<Int>,
+       val filterActivitiesCountType: State<Int>,
+       val filterDateSelections: List<DateSelection>,
+       val filterDateSelectionIndex: State<Int>,
+       val filterDistanceSelectedStart: State<Double?>,
+       val filterDistanceSelectedEnd: State<Double?>,
+       val filterDistanceTotalStart: State<Double?>,
+       val filterDistanceTotalEnd: State<Double?>,
+       val filterDistancePendingChangeStart: State<String?>,
+       val filterDistancePendingChangeEnd: State<String?>,
+       val filterTypes: Map<SportType, Boolean>,
+       @IgnoredOnParcel override val pagerStateWrapper: PagerStateWrapper = PagerStateWrapper(
+           pagerHeaders = EditArtHeaderType.values().toList(),
+           pagerState = PagerState(EditArtHeaderType.values().toList().size),
             fadeLengthMs = FADE_LENGTH_MS
         ),
-        @IgnoredOnParcel val listStateFilter: LazyListState = LazyListState(),
-        @IgnoredOnParcel val listStateStyle: LazyListState = LazyListState(),
-        @IgnoredOnParcel val scrollStateType: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
-        @IgnoredOnParcel val scrollStateResize: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
-        @IgnoredOnParcel val scrollStateSort: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
-        val sizeResolutionList: List<Resolution> = ResolutionListFactoryImpl().create(),
-        val sizeResolutionListSelectedIndex: Int = INITIAL_SELECTED_RES_INDEX,
-        val sortTypeSelected: EditArtSortType = EditArtSortType.DATE,
-        val sortDirectionTypeSelected: EditArtSortDirectionType = EditArtSortDirectionType.ASCENDING,
-        val styleActivities: ColorWrapper = ColorWrapper(
-            alpha = INIT_ACTIVITIES_ALPHA,
-            blue = INIT_ACTIVITIES_BLUE,
-            green = INIT_ACTIVITIES_GREEN,
-            red = INIT_ACTIVITIES_RED
-        ),
-        val styleBackgroundList: List<ColorWrapper> = (0 until MAX_GRADIENT_BG_COLORS).map {
-            if (it % 2 == 0) {
-                ColorWrapper(
-                    alpha = INIT_BACKGROUND_ALPHA,
-                    blue = INIT_BACKGROUND_BLUE,
-                    green = INIT_BACKGROUND_GREEN,
-                    red = INIT_BACKGROUND_RED
-                )
-            } else {
-                ColorWrapper(
-                    alpha = INIT_ACTIVITIES_ALPHA,
-                    blue = INIT_ACTIVITIES_BLUE,
-                    green = INIT_ACTIVITIES_GREEN,
-                    red = INIT_ACTIVITIES_RED
-                )
-            }
-        },
-        val styleBackgroundAngleType: AngleType = AngleType.CW90,
-        val styleBackgroundGradientColorCount: Int = MIN_GRADIENT_BG_COLORS,
-        val styleBackgroundType: BackgroundType = BackgroundType.SOLID,
-        val styleFont: ColorWrapper? = null,
-        val styleStrokeWidthType: StrokeWidthType = INIT_STROKE_WIDTH,
-        val typeActivitiesDistanceMetersSummed: Int = -1,
-        val typeFontSelected: FontType = INIT_TYPE_FONT_SELECTION,
-        val typeFontWeightSelected: FontWeightType = INIT_TYPE_FONT_WEIGHT_SELECTION,
-        val typeFontItalicized: Boolean = INIT_TYPE_IS_ITALICIZED,
-        val typeFontSizeSelected: FontSizeType = INIT_TYPE_FONT_SIZE_SELECTION,
-        @IgnoredOnParcel val typeMaximumCustomTextLength: Int = CUSTOM_TEXT_MAXIMUM_LENGTH,
-        val typeLeftSelected: EditArtTypeType = INIT_TYPE_TYPE,
-        val typeLeftCustomText: String = INIT_TYPE_CUSTOM_TEXT,
-        val typeCenterSelected: EditArtTypeType = INIT_TYPE_TYPE,
-        val typeCenterCustomText: String = INIT_TYPE_CUSTOM_TEXT,
-        val typeRightSelected: EditArtTypeType = INIT_TYPE_TYPE,
-        val typeRightCustomText: String = INIT_TYPE_CUSTOM_TEXT,
-    ) : EditArtViewState, Parcelable {
+       @IgnoredOnParcel val listStateFilter: LazyListState = LazyListState(),
+       @IgnoredOnParcel val listStateStyle: LazyListState = LazyListState(),
+       @IgnoredOnParcel val scrollStateType: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
+       @IgnoredOnParcel val scrollStateResize: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
+       @IgnoredOnParcel val scrollStateSort: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
+       val sizeResolutionList: List<Resolution>,
+       val sizeResolutionListSelectedIndex: State<Int>,
+       val sortTypeSelected: State<EditArtSortType>,
+       val sortDirectionTypeSelected: State<EditArtSortDirectionType>,
+       val styleActivities: State<ColorWrapper>,
+       val styleBackgroundList: List<ColorWrapper>,
+       val styleBackgroundAngleType: State<AngleType>,
+       val styleBackgroundGradientColorCount: State<Int>,
+       val styleBackgroundType: State<BackgroundType>,
+       val styleFont: State<ColorWrapper?>,
+       val styleStrokeWidthType: State<StrokeWidthType>,
+       val typeActivitiesDistanceMetersSummed: State<Int>,
+       val typeFontSelected: State<FontType>,
+       val typeFontWeightSelected: State<FontWeightType>,
+       val typeFontItalicized: State<Boolean>,
+       val typeFontSizeSelected: State<FontSizeType>,
+       @IgnoredOnParcel val typeMaximumCustomTextLength: Int,
+       val typeLeftSelected: State<EditArtTypeType>,
+       val typeLeftCustomText: State<String>,
+       val typeCenterSelected: State<EditArtTypeType>,
+       val typeCenterCustomText: State<String>,
+       val typeRightSelected: State<EditArtTypeType>,
+       val typeRightCustomText: State<String>,
+    ) : EditArtViewState {
 
         companion object {
             private const val INITIAL_SCROLL_STATE = 0
-            private const val INITIAL_SELECTED_RES_INDEX = 0
-
-            /** Initial Style settings **/
-            private const val INIT_ACTIVITIES_ALPHA = 1f
-            private const val INIT_ACTIVITIES_BLUE = 1f
-            private const val INIT_ACTIVITIES_GREEN = 1f
-            private const val INIT_ACTIVITIES_RED = 1f
-            private const val INIT_BACKGROUND_ALPHA = 1f
-            private const val INIT_BACKGROUND_BLUE = 0f
-            private const val INIT_BACKGROUND_GREEN = 0f
-            private const val INIT_BACKGROUND_RED = 0f
-            private val INIT_STROKE_WIDTH = StrokeWidthType.MEDIUM
-
-            /** Initial Type settings **/
-            private const val CUSTOM_TEXT_MAXIMUM_LENGTH = 30
-            private const val INIT_TYPE_CUSTOM_TEXT = ""
-            private val INIT_TYPE_FONT_SELECTION = FontType.JOSEFIN_SANS
-            private val INIT_TYPE_FONT_WEIGHT_SELECTION = FontWeightType.REGULAR
-            private val INIT_TYPE_FONT_SIZE_SELECTION = FontSizeType.MEDIUM
-            private const val INIT_TYPE_IS_ITALICIZED = false
-            private val INIT_TYPE_TYPE = EditArtTypeType.NONE
-
-            private const val NO_ACTIVITIES_COUNT = 0
-
-            private const val INIT_SELECTION_INDEX = 0
         }
 
         @Inject
         @IgnoredOnParcel
         lateinit var resolutionListFactory: ResolutionListFactory
 
+        /*
         @IgnoredOnParcel
         val atLeastOneActivitySelected
             get() = minOf(
@@ -295,6 +252,7 @@ sealed interface EditArtViewState : ViewState {
                         ?: Int.MAX_VALUE
                 )
 
+         */
     }
 }
 
@@ -340,6 +298,20 @@ data class ColorWrapper(
 
         val RATIO_RANGE = RATIO_LIMIT_LOWER..RATIO_LIMIT_UPPER
         val EIGHT_BIT_RANGE = EIGHT_BIT_LIMIT_LOWER..EIGHT_BIT_LIMIT_UPPER
+
+        val Black = ColorWrapper(
+            alpha = 1f,
+            blue = 0f,
+            green = 0f,
+            red = 0f
+        )
+
+        val White = ColorWrapper(
+            alpha = 1f,
+            blue = 1f,
+            green = 1f,
+            red = 1f
+        )
     }
 
     fun toInvertedLuminanceGrayscaleColor() = (RATIO_LIMIT_UPPER - toColor().luminance()).let {

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.*
 import androidx.compose.runtime.snapshots.SnapshotMutableState
 import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.res.stringResource
 import com.activityartapp.R
@@ -177,7 +178,7 @@ sealed interface EditArtViewState : ViewState {
        val filterActivitiesCountDate: State<Int>,
        val filterActivitiesCountDistance: State<Int>,
        val filterActivitiesCountType: State<Int>,
-       val filterDateSelections: List<DateSelection>,
+       val filterDateSelections: SnapshotStateList<DateSelection>,
        val filterDateSelectionIndex: State<Int>,
        val filterDistanceSelectedStart: State<Double?>,
        val filterDistanceSelectedEnd: State<Double?>,
@@ -185,7 +186,7 @@ sealed interface EditArtViewState : ViewState {
        val filterDistanceTotalEnd: State<Double?>,
        val filterDistancePendingChangeStart: State<String?>,
        val filterDistancePendingChangeEnd: State<String?>,
-       val filterTypes: Map<SportType, Boolean>,
+       val filterTypes: SnapshotStateMap<SportType, Boolean>,
        @IgnoredOnParcel override val pagerStateWrapper: PagerStateWrapper = PagerStateWrapper(
            pagerHeaders = EditArtHeaderType.values().toList(),
            pagerState = PagerState(EditArtHeaderType.values().toList().size),
@@ -201,7 +202,7 @@ sealed interface EditArtViewState : ViewState {
        val sortTypeSelected: State<EditArtSortType>,
        val sortDirectionTypeSelected: State<EditArtSortDirectionType>,
        val styleActivities: State<ColorWrapper>,
-       val styleBackgroundList: List<ColorWrapper>,
+       val styleBackgroundList: SnapshotStateList<ColorWrapper>,
        val styleBackgroundAngleType: State<AngleType>,
        val styleBackgroundGradientColorCount: State<Int>,
        val styleBackgroundType: State<BackgroundType>,

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
@@ -10,7 +10,9 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -18,6 +20,7 @@ import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.activityartapp.R
+import com.activityartapp.architecture.EventReceiver
 import com.activityartapp.presentation.common.AppBarScaffold
 import com.activityartapp.presentation.common.ScreenBackground
 import com.activityartapp.presentation.editArtScreen.EditArtHeaderType.*
@@ -35,30 +38,36 @@ import com.activityartapp.util.classes.YearMonthDay
 import com.activityartapp.util.enums.BackgroundType
 import com.google.accompanist.pager.ExperimentalPagerApi
 
-/**
- * A complex screen featuring [EditArtTabLayout]
- */
 @OptIn(ExperimentalPagerApi::class)
 @Composable
 fun EditArtViewDelegate(viewModel: EditArtViewModel) {
     viewModel.viewState.collectAsState().value?.apply {
-  // todo      val continueEnabled = (this@apply as? EditArtViewState.Standby)?.atLeastOneActivitySelected
-        val continueEnabled: Boolean? = true
-        val atLeastOneActivitySelected: Boolean = true // todo
+        /* Triggers a recomposition only when all activity counts do not equal zero
+        or at least one does. */
+        val atLeastOneActivitySelected = derivedStateOf {
+            (this as? EditArtViewState.Standby)?.run {
+                (filterActivitiesCountDate.value != 0)
+                    .and(filterActivitiesCountDate.value != 0)
+                    .and(filterActivitiesCountDistance.value != 0)
+            } ?: false
+        }
+
         AppBarScaffold(
             text = stringResource(R.string.action_bar_edit_art_header),
             onNavigateUp = { viewModel.onEventDebounced(NavigateUpClicked) },
             actions = {
                 IconButton(
                     onClick = { viewModel.onEventDebounced(SaveClicked) },
-                    enabled = continueEnabled ?: false
+                    enabled = atLeastOneActivitySelected.value
                 ) {
                     Text(
                         text = stringResource(R.string.button_continue_uppercase),
                         style = MaterialTheme.typography.button,
-                        color = continueEnabled?.takeIf { it }?.let {
+                        color = if (atLeastOneActivitySelected.value) {
                             MaterialTheme.colors.onPrimary
-                        } ?: Color.Unspecified
+                        } else {
+                            Color.Unspecified
+                        }
                     )
                 }
                 Spacer(modifier = Modifier.width(spacing.medium))
@@ -74,8 +83,13 @@ fun EditArtViewDelegate(viewModel: EditArtViewModel) {
             }
         ) {
             if (this@apply is EditArtViewState.Standby) {
-                val activeHeader =
-                    EditArtHeaderType.fromOrdinal(pagerStateWrapper.pagerState.currentPage)
+                val activeHeader = EditArtHeaderType
+                    .fromOrdinal(pagerStateWrapper.pagerState.currentPage)
+
+                val backgroundIsTransparent = derivedStateOf {
+                    styleBackgroundType.value == BackgroundType.TRANSPARENT
+                }
+
                 Crossfade(
                     targetState = activeHeader,
                     animationSpec = tween(500, easing = FastOutSlowInEasing)
@@ -94,8 +108,8 @@ fun EditArtViewDelegate(viewModel: EditArtViewModel) {
                         when (it) {
                             PREVIEW -> EditArtPreview(
                                 atLeastOneActivitySelected,
-                                styleBackgroundType.value == BackgroundType.TRANSPARENT,
-                                bitmap.value,
+                                backgroundIsTransparent,
+                                bitmap,
                                 viewModel
                             )
                             FILTERS -> YearMonthDay.run {
@@ -119,7 +133,8 @@ fun EditArtViewDelegate(viewModel: EditArtViewModel) {
                             STYLE -> EditArtStyleScreen(
                                 styleBackgroundType,
                                 styleBackgroundAngleType,
-                                styleBackgroundList, // todo need to add a paremter
+                                styleBackgroundGradientColorCount,
+                                styleBackgroundList,
                                 styleActivities,
                                 styleFont,
                                 listStateStyle,
@@ -158,40 +173,51 @@ fun EditArtViewDelegate(viewModel: EditArtViewModel) {
             }
         }
 
-        /** Only intercept when the dialog box is not visible **/
-        BackHandler(enabled = dialogActive.value is EditArtDialog.None) {
-            viewModel.onEvent(NavigateUpClicked)
-        }
+        DialogHandler(
+            dialogActive = dialogActive,
+            eventReceiver = viewModel
+        )
+    }
+}
 
-        when (dialogActive.value) {
-            is EditArtDialog.ConfirmDeleteGradientColor -> {
-                EditArtDialogInfo(
-                    body = stringArrayResource(id = R.array.edit_art_dialog_info_remove_gradient_color),
-                    eventReceiver = viewModel,
-                    type = EditArtDialogType.REMOVE_AND_DISMISS_BY_CANCEL
-                )
-            }
-            is EditArtDialog.InfoCheckeredBackground -> EditArtDialogInfo(
-                body = stringArrayResource(id = R.array.edit_art_dialog_info_background_checkered),
-                eventReceiver = viewModel,
-                type = EditArtDialogType.DISMISS_BY_OK
+@Composable
+private fun DialogHandler(
+    dialogActive: State<EditArtDialog>,
+    eventReceiver: EventReceiver<EditArtViewEvent>
+) {
+    /** Only intercept when the dialog box is not visible **/
+    BackHandler(enabled = dialogActive.value is EditArtDialog.None) {
+        eventReceiver.onEvent(NavigateUpClicked)
+    }
+
+    when (dialogActive.value) {
+        is EditArtDialog.ConfirmDeleteGradientColor -> {
+            EditArtDialogInfo(
+                body = stringArrayResource(id = R.array.edit_art_dialog_info_remove_gradient_color),
+                eventReceiver = eventReceiver,
+                type = EditArtDialogType.REMOVE_AND_DISMISS_BY_CANCEL
             )
-            is EditArtDialog.InfoGradientBackground -> EditArtDialogInfo(
-                body = stringArrayResource(id = R.array.edit_art_dialog_info_background_gradient),
-                eventReceiver = viewModel,
-                type = EditArtDialogType.DISMISS_BY_OK
-            )
-            is EditArtDialog.InfoTransparent -> EditArtDialogInfo(
-                body = stringArrayResource(id = R.array.edit_art_dialog_info_background_transparent),
-                eventReceiver = viewModel,
-                type = EditArtDialogType.DISMISS_BY_OK
-            )
-            is EditArtDialog.NavigateUp -> EditArtDialogInfo(
-                body = stringArrayResource(id = R.array.edit_art_dialog_exit_confirmation_prompt),
-                eventReceiver = viewModel,
-                type = EditArtDialogType.DISCARD_AND_DISMISS_BY_CANCEL
-            )
-            is EditArtDialog.None -> {} // No-op
         }
+        is EditArtDialog.InfoCheckeredBackground -> EditArtDialogInfo(
+            body = stringArrayResource(id = R.array.edit_art_dialog_info_background_checkered),
+            eventReceiver = eventReceiver,
+            type = EditArtDialogType.DISMISS_BY_OK
+        )
+        is EditArtDialog.InfoGradientBackground -> EditArtDialogInfo(
+            body = stringArrayResource(id = R.array.edit_art_dialog_info_background_gradient),
+            eventReceiver = eventReceiver,
+            type = EditArtDialogType.DISMISS_BY_OK
+        )
+        is EditArtDialog.InfoTransparent -> EditArtDialogInfo(
+            body = stringArrayResource(id = R.array.edit_art_dialog_info_background_transparent),
+            eventReceiver = eventReceiver,
+            type = EditArtDialogType.DISMISS_BY_OK
+        )
+        is EditArtDialog.NavigateUp -> EditArtDialogInfo(
+            body = stringArrayResource(id = R.array.edit_art_dialog_exit_confirmation_prompt),
+            eventReceiver = eventReceiver,
+            type = EditArtDialogType.DISCARD_AND_DISMISS_BY_CANCEL
+        )
+        is EditArtDialog.None -> {} // No-op
     }
 }

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
@@ -127,28 +127,28 @@ fun EditArtViewDelegate(viewModel: EditArtViewModel) {
                                 viewModel
                             )
                             TYPE -> EditArtTypeScreen(
-                                typeActivitiesDistanceMetersSummed.value,
-                                typeCenterCustomText.value,
-                                typeLeftCustomText.value,
-                                typeRightCustomText.value,
-                                typeFontSelected.value,
-                                typeFontWeightSelected.value,
-                                typeFontItalicized.value,
-                                typeFontSizeSelected.value,
+                                typeActivitiesDistanceMetersSummed,
+                                typeCenterCustomText,
+                                typeLeftCustomText,
+                                typeRightCustomText,
+                                typeFontSelected,
+                                typeFontWeightSelected,
+                                typeFontItalicized,
+                                typeFontSizeSelected,
                                 typeMaximumCustomTextLength,
-                                typeCenterSelected.value,
-                                typeLeftSelected.value,
-                                typeRightSelected.value,
+                                typeCenterSelected,
+                                typeLeftSelected,
+                                typeRightSelected,
                                 viewModel
                             )
                             SORT -> EditArtSortScreen(
-                                sortTypeSelected = sortTypeSelected.value,
-                                sortDirectionSelected = sortDirectionTypeSelected.value,
+                                sortTypeSelected = sortTypeSelected,
+                                sortDirectionSelected = sortDirectionTypeSelected,
                                 eventReceiver = viewModel
                             )
                             RESIZE -> EditArtResizeScreen(
                                 sizeResolutionList,
-                                sizeResolutionListSelectedIndex.value,
+                                sizeResolutionListSelectedIndex,
                                 viewModel
                             )
                             null -> error("Invalid pagerState current page.")

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
@@ -100,32 +100,30 @@ fun EditArtViewDelegate(viewModel: EditArtViewModel) {
                             )
                             FILTERS -> YearMonthDay.run {
                                 EditArtFiltersScreen(
-                                    filterActivitiesCountDate.value,
-                                    filterActivitiesCountDistance.value,
-                                    filterActivitiesCountType.value,
+                                    filterActivitiesCountDate,
+                                    filterActivitiesCountDistance,
+                                    filterActivitiesCountType,
                                     filterDateSelections,
-                                    filterDateSelectionIndex.value,
-                                    filterDistanceSelectedEnd.value?.let {
-                                        filterDistanceSelectedStart.value?.rangeTo(it)
-                                    },
-                                    filterDistanceTotalEnd.value?.let {
-                                        filterDistanceTotalStart.value?.rangeTo(it)
-                                    },
-                                    filterDistancePendingChangeStart.value,
-                                    filterDistancePendingChangeEnd.value,
+                                    filterDateSelectionIndex,
+                                    filterDistanceSelectedStart,
+                                    filterDistanceSelectedEnd,
+                                    filterDistanceTotalStart,
+                                    filterDistanceTotalEnd,
+                                    filterDistancePendingChangeStart,
+                                    filterDistancePendingChangeEnd,
                                     listStateFilter,
-                                    filterTypes?.toList(),
+                                    filterTypes,
                                     viewModel
                                 )
                             }
                             STYLE -> EditArtStyleScreen(
-                                styleBackgroundType.value,
-                                styleBackgroundAngleType.value,
-                                styleBackgroundList.take(styleBackgroundGradientColorCount.value),
-                                styleActivities.value,
-                                styleFont.value,
+                                styleBackgroundType,
+                                styleBackgroundAngleType,
+                                styleBackgroundList, // todo need to add a paremter
+                                styleActivities,
+                                styleFont,
                                 listStateStyle,
-                                styleStrokeWidthType.value,
+                                styleStrokeWidthType,
                                 viewModel
                             )
                             TYPE -> EditArtTypeScreen(

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
@@ -42,7 +42,9 @@ import com.google.accompanist.pager.ExperimentalPagerApi
 @Composable
 fun EditArtViewDelegate(viewModel: EditArtViewModel) {
     viewModel.viewState.collectAsState().value?.apply {
-        val continueEnabled = (this@apply as? EditArtViewState.Standby)?.atLeastOneActivitySelected
+  // todo      val continueEnabled = (this@apply as? EditArtViewState.Standby)?.atLeastOneActivitySelected
+        val continueEnabled: Boolean? = true
+        val atLeastOneActivitySelected: Boolean = true // todo
         AppBarScaffold(
             text = stringResource(R.string.action_bar_edit_art_header),
             onNavigateUp = { viewModel.onEventDebounced(NavigateUpClicked) },
@@ -92,63 +94,63 @@ fun EditArtViewDelegate(viewModel: EditArtViewModel) {
                         when (it) {
                             PREVIEW -> EditArtPreview(
                                 atLeastOneActivitySelected,
-                                styleBackgroundType == BackgroundType.TRANSPARENT,
-                                bitmap,
+                                styleBackgroundType.value == BackgroundType.TRANSPARENT,
+                                bitmap.value,
                                 viewModel
                             )
                             FILTERS -> YearMonthDay.run {
                                 EditArtFiltersScreen(
-                                    filterActivitiesCountDate,
-                                    filterActivitiesCountDistance,
-                                    filterActivitiesCountType,
+                                    filterActivitiesCountDate.value,
+                                    filterActivitiesCountDistance.value,
+                                    filterActivitiesCountType.value,
                                     filterDateSelections,
-                                    filterDateSelectionIndex,
-                                    filterDistanceSelectedEnd?.let {
-                                        filterDistanceSelectedStart?.rangeTo(it)
+                                    filterDateSelectionIndex.value,
+                                    filterDistanceSelectedEnd.value?.let {
+                                        filterDistanceSelectedStart.value?.rangeTo(it)
                                     },
-                                    filterDistanceTotalEnd?.let {
-                                        filterDistanceTotalStart?.rangeTo(it)
+                                    filterDistanceTotalEnd.value?.let {
+                                        filterDistanceTotalStart.value?.rangeTo(it)
                                     },
-                                    filterDistancePendingChangeStart,
-                                    filterDistancePendingChangeEnd,
+                                    filterDistancePendingChangeStart.value,
+                                    filterDistancePendingChangeEnd.value,
                                     listStateFilter,
                                     filterTypes?.toList(),
                                     viewModel
                                 )
                             }
                             STYLE -> EditArtStyleScreen(
-                                styleBackgroundType,
-                                styleBackgroundAngleType,
-                                styleBackgroundList.take(styleBackgroundGradientColorCount),
-                                styleActivities,
-                                styleFont,
+                                styleBackgroundType.value,
+                                styleBackgroundAngleType.value,
+                                styleBackgroundList.take(styleBackgroundGradientColorCount.value),
+                                styleActivities.value,
+                                styleFont.value,
                                 listStateStyle,
-                                styleStrokeWidthType,
+                                styleStrokeWidthType.value,
                                 viewModel
                             )
                             TYPE -> EditArtTypeScreen(
-                                typeActivitiesDistanceMetersSummed,
-                                typeCenterCustomText,
-                                typeLeftCustomText,
-                                typeRightCustomText,
-                                typeFontSelected,
-                                typeFontWeightSelected,
-                                typeFontItalicized,
-                                typeFontSizeSelected,
+                                typeActivitiesDistanceMetersSummed.value,
+                                typeCenterCustomText.value,
+                                typeLeftCustomText.value,
+                                typeRightCustomText.value,
+                                typeFontSelected.value,
+                                typeFontWeightSelected.value,
+                                typeFontItalicized.value,
+                                typeFontSizeSelected.value,
                                 typeMaximumCustomTextLength,
-                                typeCenterSelected,
-                                typeLeftSelected,
-                                typeRightSelected,
+                                typeCenterSelected.value,
+                                typeLeftSelected.value,
+                                typeRightSelected.value,
                                 viewModel
                             )
                             SORT -> EditArtSortScreen(
-                                sortTypeSelected = sortTypeSelected,
-                                sortDirectionSelected = sortDirectionTypeSelected,
+                                sortTypeSelected = sortTypeSelected.value,
+                                sortDirectionSelected = sortDirectionTypeSelected.value,
                                 eventReceiver = viewModel
                             )
                             RESIZE -> EditArtResizeScreen(
                                 sizeResolutionList,
-                                sizeResolutionListSelectedIndex,
+                                sizeResolutionListSelectedIndex.value,
                                 viewModel
                             )
                             null -> error("Invalid pagerState current page.")
@@ -159,11 +161,11 @@ fun EditArtViewDelegate(viewModel: EditArtViewModel) {
         }
 
         /** Only intercept when the dialog box is not visible **/
-        BackHandler(enabled = dialogActive is EditArtDialog.None) {
+        BackHandler(enabled = dialogActive.value is EditArtDialog.None) {
             viewModel.onEvent(NavigateUpClicked)
         }
 
-        when (dialogActive) {
+        when (dialogActive.value) {
             is EditArtDialog.ConfirmDeleteGradientColor -> {
                 EditArtDialogInfo(
                     body = stringArrayResource(id = R.array.edit_art_dialog_info_remove_gradient_color),

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
@@ -69,7 +69,7 @@ class EditArtViewModel @Inject constructor(
         private const val SSH_STYLE_FONT = "styleFont"
         private const val SSH_STYLE_STROKE_WIDTH_TYPE = "strokeWidthType"
         private const val SSH_TYPE_ACTIVITIES_DISTANCE_METERS_SUMMED =
-            "typeActivitiesDistanceMetersSummed" // Todo, determine if need to be saved
+            "typeActivitiesDistanceMetersSummed"
         private const val SSH_TYPE_FONT_SELECTED = "typeFontSelected"
         private const val SSH_TYPE_FONT_WEIGHT_SELECTED = "typeFontWeightSelected"
         private const val SSH_TYPE_FONT_ITALICIZED = "typeFontItalicized"
@@ -200,7 +200,6 @@ class EditArtViewModel @Inject constructor(
     private val EditArtFilterType.activitiesCount: Int
         get() = activitiesFilteredByFilterType[this]?.size ?: 0
 
-    // DONE
     private fun EditArtFilterType.pushUpdatedFilteredActivityCountToView() {
         when (this@pushUpdatedFilteredActivityCountToView) {
             DATE -> _filterActivitiesCountDate.value = DATE.activitiesCount
@@ -212,16 +211,12 @@ class EditArtViewModel @Inject constructor(
         }
     }
 
-    /** region Unsaved States unobserved in View */
+    /** region States unobserved in View */
     private val activitiesProcessingDispatcher by lazy { Dispatchers.Default.limitedParallelism(1) }
     private val imageProcessingDispatcher by lazy { Dispatchers.Default.limitedParallelism(1) }
     /** endregion **/
 
-    /** region Saved States unobserved in View */
-
-    /** endregion **/
-
-    /** region Saved States observed in View */
+    /** region States observed in View */
     // GLOBAL
     private val _dialogActive = mutableStateOf<EditArtDialog>(EditArtDialog.None) // not save
 
@@ -275,7 +270,6 @@ class EditArtViewModel @Inject constructor(
     private val _typeCenterCustomText = mutableStateOf("")
     private val _typeRightSelected = mutableStateOf(EditArtTypeType.NONE)
     private val _typeRightCustomText = mutableStateOf("")
-
     /** endregion **/
 
     init {
@@ -351,20 +345,22 @@ class EditArtViewModel @Inject constructor(
     }
 
     override fun onEvent(event: EditArtViewEvent) {
-        when (event) {
-            is ArtMutatingEvent -> onArtMutatingEvent(event)
-            is ClickedRemoveGradientColor -> onClickedRemoveGradientColor(event)
-            is ClickedInfoCheckeredBackground -> onClickedInfoCheckeredBackground()
-            is ClickedInfoGradientBackground -> onClickedInfoGradientBackground()
-            is ClickedInfoTransparentBackground -> onClickedInfoTransparentBackground()
-            is DialogDismissed -> onDialogDismissed()
-            is DialogNavigateUpConfirmed -> onDialogNavigateUpConfirmed()
-            is FilterDistancePendingChange -> onFilterDistancePendingChange(event)
-            is NavigateUpClicked -> onNavigateUpClicked()
-            is SaveClicked -> onSaveClicked()
-            is SizeCustomPendingChanged -> onSizeCustomPendingChanged(event)
-            is StyleColorPendingChanged -> onStyleColorPendingChanged(event)
-            is PageHeaderClicked -> onPageHeaderClicked(event)
+        viewModelScope.launch {
+            when (event) {
+                is ArtMutatingEvent -> onArtMutatingEvent(event)
+                is ClickedRemoveGradientColor -> onClickedRemoveGradientColor(event)
+                is ClickedInfoCheckeredBackground -> onClickedInfoCheckeredBackground()
+                is ClickedInfoGradientBackground -> onClickedInfoGradientBackground()
+                is ClickedInfoTransparentBackground -> onClickedInfoTransparentBackground()
+                is DialogDismissed -> onDialogDismissed()
+                is DialogNavigateUpConfirmed -> onDialogNavigateUpConfirmed()
+                is FilterDistancePendingChange -> onFilterDistancePendingChange(event)
+                is NavigateUpClicked -> onNavigateUpClicked()
+                is SaveClicked -> onSaveClicked()
+                is SizeCustomPendingChanged -> onSizeCustomPendingChanged(event)
+                is StyleColorPendingChanged -> onStyleColorPendingChanged(event)
+                is PageHeaderClicked -> onPageHeaderClicked(event)
+            }
         }
     }
 
@@ -393,7 +389,7 @@ class EditArtViewModel @Inject constructor(
             is TypeSelectionChanged -> onTypeSelectionChanged(event)
         }
         if (event !is FilterChanged) {
-            // updateBitmap()
+            updateBitmap()
         }
     }
 
@@ -428,45 +424,37 @@ class EditArtViewModel @Inject constructor(
         }
     }
 
-    // DONE
     private fun onClickedRemoveGradientColor(event: ClickedRemoveGradientColor) {
         _dialogActive.value = EditArtDialog.ConfirmDeleteGradientColor(
             toDeleteIndex = event.removedIndex
         )
     }
 
-    // DONE
     private fun onClickedInfoCheckeredBackground() {
         _dialogActive.value = EditArtDialog.InfoCheckeredBackground
     }
 
-    // DONE
     private fun onClickedInfoGradientBackground() {
         _dialogActive.value = EditArtDialog.InfoGradientBackground
     }
 
-    // DONE
     private fun onClickedInfoTransparentBackground() {
         _dialogActive.value = EditArtDialog.InfoTransparent
     }
 
-    // DONE
     private fun onDialogDismissed() {
         _dialogActive.value = EditArtDialog.None
     }
 
-    // DONE
     private fun onDialogNavigateUpConfirmed() {
         _dialogActive.value = EditArtDialog.None
         viewModelScope.launch { routeTo(NavigateUp) }
     }
 
-    // DONE
     private fun onFilterDateSelectionChanged(event: FilterChanged.FilterDateSelectionChanged) {
         _filterDateSelectionIndex.value = event.index
     }
 
-    // DONE
     private fun onFilterDateCustomChanged(event: FilterChanged.FilterDateCustomChanged) {
         val customIndex = _filterDateSelections.indexOfFirst { it is DateSelection.Custom }
         val updatedDateSelection =
@@ -494,7 +482,6 @@ class EditArtViewModel @Inject constructor(
         _filterDateSelections[customIndex] = updatedDateSelection
     }
 
-    // DONE
     private fun onFilterDistanceChanged(event: FilterChanged.FilterDistanceChanged) {
         _filterDistanceSelectedStart.value = event.changedTo.start
         _filterDistanceSelectedEnd.value = event.changedTo.endInclusive
@@ -502,7 +489,6 @@ class EditArtViewModel @Inject constructor(
         _filterDistancePendingChangeEnd.value = null
     }
 
-    // DONE
     private fun onFilterDistancePendingChange(event: FilterDistancePendingChange) {
         if (event is FilterDistancePendingChange.FilterDistancePendingChangeShortest) {
             _filterDistancePendingChangeStart.value = event.changedTo
@@ -511,7 +497,6 @@ class EditArtViewModel @Inject constructor(
         }
     }
 
-    // DONE
     private fun onFilterDistancePendingChangeConfirmed(event: FilterChanged.FilterDistancePendingChangeConfirmed) {
         val totalValueSmallest = _filterDistanceTotalStart.value ?: 0.0
         val totalValueLargest = _filterDistanceTotalEnd.value ?: Double.MAX_VALUE
@@ -542,12 +527,10 @@ class EditArtViewModel @Inject constructor(
         }
     }
 
-    // DONE
     private fun onFilterTypeToggled(event: FilterChanged.FilterTypeToggled) {
         _filterTypes[event.type] = _filterTypes[event.type]!!.not()
     }
 
-    //  DONE
     private fun onNavigateUpClicked() {
         _dialogActive.value = EditArtDialog.NavigateUp
     }
@@ -601,7 +584,6 @@ class EditArtViewModel @Inject constructor(
         }
     }
 
-    // DONE
     private fun onStyleColorPendingChanged(event: StyleColorPendingChanged) {
         when (event.style) {
             is StyleIdentifier.Activities -> {
@@ -633,7 +615,6 @@ class EditArtViewModel @Inject constructor(
         _sizeResolutionListSelectedIndex.value = event.changedIndex
     }
 
-    // DONE
     private fun onSizeCustomChanged(event: SizeCustomChanged) {
         val customRes = _sizeResolutionList[event.customIndex] as Resolution.CustomResolution
         _sizeResolutionList[event.customIndex] = if (event.heightChanged) {
@@ -644,7 +625,6 @@ class EditArtViewModel @Inject constructor(
         _sizeResolutionListSelectedIndex.value = event.customIndex
     }
 
-    // DONE
     private fun onSizeCustomPendingChangeConfirmed(event: SizeCustomPendingChangeConfirmed) {
         val customRes = _sizeResolutionList[event.customIndex] as Resolution.CustomResolution
         val range = customRes.sizeRangePx
@@ -663,7 +643,6 @@ class EditArtViewModel @Inject constructor(
         _sizeResolutionListSelectedIndex.value = event.customIndex
     }
 
-    // DONE
     private fun onSizeCustomPendingChanged(event: SizeCustomPendingChanged) {
         _sizeResolutionList.apply {
             val tarIndex = indexOfFirst { it is Resolution.CustomResolution }
@@ -676,7 +655,6 @@ class EditArtViewModel @Inject constructor(
         }
     }
 
-    // DONE
     private fun onSizeRotated(event: SizeRotated) {
         val prevRes = _sizeResolutionList[event.rotatedIndex]
         val adjRes = (prevRes as? Resolution.RotatingResolution
@@ -685,24 +663,20 @@ class EditArtViewModel @Inject constructor(
         _sizeResolutionList[event.rotatedIndex] = adjRes
     }
 
-    // DONE
     private fun onSortDirectionChanged(event: SortDirectionChanged) {
         _sortDirectionTypeSelected.value = event.changedTo
     }
 
-    // DONE
     private fun onSortTypeChanged(event: SortTypeChanged) {
         _sortTypeSelected.value = event.changedTo
     }
 
-    // DONE
     private fun onStyleBackgroundColorAdded() {
         val prevCount = _styleBackgroundGradientColorCount.value
         if (prevCount >= 7) return // todo
         _styleBackgroundGradientColorCount.value = prevCount.inc()
     }
 
-    // DONE
     private fun onStyleBackgroundColorRemoveConfirmed() {
         val prevCount = _styleBackgroundGradientColorCount.value
         if (prevCount <= 2) return // todo
@@ -721,12 +695,10 @@ class EditArtViewModel @Inject constructor(
         _styleBackgroundGradientColorCount.value = prevCount.dec()
     }
 
-    // DONE
     private fun onStyleBackgroundTypeChanged(event: StyleBackgroundTypeChanged) {
         _styleBackgroundType.value = event.changedTo
     }
 
-    // DONE
     private fun onStyleColorChanged(event: StyleColorChanged) {
         when (event.style) {
             is StyleIdentifier.Activities -> _styleActivities.value =
@@ -749,7 +721,6 @@ class EditArtViewModel @Inject constructor(
         }
     }
 
-    // DONE
     private fun onStyleColorPendingChangeConfirmed(event: StyleColorPendingChangeConfirmed) {
         when (event.style) {
             is StyleIdentifier.Activities -> _styleActivities.value =
@@ -762,7 +733,6 @@ class EditArtViewModel @Inject constructor(
         }
     }
 
-    // DONE
     private fun onStyleColorFontUseCustomChanged(event: StyleColorFontUseCustomChanged) {
         _styleFont.value = if (event.useCustom) {
             _styleFont.value ?: _styleActivities.value
@@ -771,17 +741,14 @@ class EditArtViewModel @Inject constructor(
         }
     }
 
-    // DONE
     private fun onStyleGradientAngleTypeChanged(event: StyleGradientAngleTypeChanged) {
         _styleBackgroundAngleType.value = event.changedTo
     }
 
-    // DONE
     private fun onStyleStrokeWidthChanged(event: StyleStrokeWidthChanged) {
         _styleStrokeWidthType.value = event.changedTo
     }
 
-    // DONE
     private fun onTypeCustomTextChanged(event: TypeCustomTextChanged) {
         val newText = event.changedTo.takeIf { it.length <= _typeMaximumCustomTextLength }
         when (event.section) {
@@ -801,7 +768,6 @@ class EditArtViewModel @Inject constructor(
         }
     }
 
-    // DONE
     private fun onTypeFontChanged(event: TypeFontChanged) {
         event.changedTo.run {
             _typeFontItalicized.value = _typeFontItalicized.value && isItalic
@@ -815,12 +781,10 @@ class EditArtViewModel @Inject constructor(
         }
     }
 
-    // DONE
     private fun onTypeFontSizeChanged(event: TypeFontSizeChanged) {
         _typeFontSizeSelected.value = event.changedTo
     }
 
-    // DONE
     private fun onTypeSelectionChanged(event: TypeSelectionChanged) {
         when (event.section) {
             EditArtTypeSection.LEFT -> _typeLeftSelected.value = event.typeSelected
@@ -829,12 +793,10 @@ class EditArtViewModel @Inject constructor(
         }
     }
 
-    // DONE
     private fun onTypeFontWeightChanged(event: TypeFontWeightChanged) {
         _typeFontWeightSelected.value = event.changedTo
     }
 
-    // DONE
     private fun onTypeFontItalicChanged(event: TypeFontItalicChanged) {
         _typeFontItalicized.value = event.changedTo
     }

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/composables/Section.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/composables/Section.kt
@@ -8,6 +8,8 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import com.activityartapp.presentation.common.layout.ColumnMediumSpacing
 import com.activityartapp.presentation.common.layout.ColumnSmallSpacing
 import com.activityartapp.presentation.ui.theme.spacing
@@ -21,30 +23,49 @@ interface Section {
 fun Section(
     header: String,
     description: String? = null,
+    excludePadding: Boolean = false,
     includeDivider: Boolean = true,
     content: @Composable ColumnScope.() -> Unit
 ) {
     ColumnMediumSpacing(
         modifier = Modifier
             .background(MaterialTheme.colors.surface)
-            .padding(spacing.medium),
+            .padding(
+                if (!excludePadding) {
+                    spacing.medium
+                } else {
+                    0.dp
+                }
+            ),
         horizontalAlignment = Alignment.Start
     ) {
-        ColumnSmallSpacing(
-            horizontalAlignment = Alignment.Start,
-            modifier = Modifier.fillMaxSize()
+        ColumnMediumSpacing(
+            modifier = Modifier.padding(
+                if (excludePadding) {
+                    spacing.medium
+                } else {
+                    0.dp
+                }
+            )
         ) {
-            Text(
-                text = header,
-                style = MaterialTheme.typography.h5
-            )
-            Divider()
-        }
-        description?.let {
-            Text(
-                text = it,
-                style = MaterialTheme.typography.body1
-            )
+            ColumnSmallSpacing(
+                horizontalAlignment = Alignment.Start,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    text = header,
+                    style = MaterialTheme.typography.h5
+                )
+                Divider()
+            }
+            description?.let {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = it,
+                    textAlign = TextAlign.Start,
+                    style = MaterialTheme.typography.body1
+                )
+            }
         }
         ColumnSmallSpacing(
             horizontalAlignment = Alignment.Start,

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/composables/TextFieldSliders.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/composables/TextFieldSliders.kt
@@ -1,10 +1,8 @@
 package com.activityartapp.presentation.editArtScreen.composables
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.MaterialTheme
@@ -15,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -45,6 +44,7 @@ fun TextFieldSliders(
             val interactionSource = remember { MutableInteractionSource() }
             ColumnSmallSpacing {
                 Row(
+                    modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(spacing.small)
                 ) {
@@ -71,6 +71,7 @@ fun TextFieldSliders(
                         interactionSource = interactionSource,
                     )
                     Slider(
+                        modifier = Modifier.weight(1f, true),
                         value = spec.sliderValue,
                         onValueChange = spec.onSliderChanged,
                         valueRange = spec.sliderRange

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/filters/EditArtFiltersScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/filters/EditArtFiltersScreen.kt
@@ -5,6 +5,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.res.stringResource
 import com.activityartapp.R
 import com.activityartapp.presentation.editArtScreen.subscreens.filters.sections.SectionActivityType
@@ -19,27 +22,29 @@ import com.activityartapp.util.enums.SportType
 
 @Composable
 fun EditArtFiltersScreen(
-    activitiesCountDate: Int,
-    activitiesCountDistance: Int,
-    activitiesCountType: Int,
-    filterDateSelections: List<DateSelection>?,
-    filterDateSelectionIndex: Int,
-    distanceSelected: ClosedFloatingPointRange<Double>?,
-    distanceTotal: ClosedFloatingPointRange<Double>?,
-    distancePendingChangeStart: String?,
-    distancePendingChangeEnd: String?,
+    activitiesCountDate: State<Int>,
+    activitiesCountDistance: State<Int>,
+    activitiesCountType: State<Int>,
+    filterDateSelections: SnapshotStateList<DateSelection>,
+    filterDateSelectionIndex: State<Int>,
+    distanceSelectedStart: State<Double?>,
+    distanceSelectedEnd: State<Double?>,
+    distanceTotalStart: State<Double?>,
+    distanceTotalEnd: State<Double?>,
+    distancePendingChangeStart: State<String?>,
+    distancePendingChangeEnd: State<String?>,
     listState: LazyListState,
-    typesWithSelectedFlag: List<Pair<SportType, Boolean>>?,
+    typesWithSelectedFlag: SnapshotStateMap<SportType, Boolean>,
     eventReceiver: EventReceiver<EditArtViewEvent>
 ) {
     val sections = mutableListOf<EditArtFiltersSectionType>().apply {
-        if (filterDateSelections != null) {
+        if (filterDateSelections.isNotEmpty()) {
             add(EditArtFiltersSectionType.DATE)
         }
-        if (typesWithSelectedFlag != null) {
+        if (typesWithSelectedFlag.isNotEmpty()) {
             add(EditArtFiltersSectionType.ACTIVITY_TYPE)
         }
-        if (distanceTotal != null && distanceTotal.start != distanceTotal.endInclusive) {
+        if (distanceTotalStart.value != null) { // todo add back start != end case
             add(EditArtFiltersSectionType.DISTANCE)
         }
     }
@@ -53,28 +58,28 @@ fun EditArtFiltersScreen(
                 description = section.descriptionStrRes?.let { stringResource(it) }
             ) {
                 when (section) {
-                    EditArtFiltersSectionType.DATE -> filterDateSelections?.let {
-                        SectionDate(
-                            count = activitiesCountDate,
-                            dateSelections = it,
-                            dateSelectionSelectedIndex = filterDateSelectionIndex,
-                            eventReceiver = eventReceiver
-                        )
-                    }
-                    EditArtFiltersSectionType.ACTIVITY_TYPE -> typesWithSelectedFlag?.let {
-                        SectionActivityType(
-                            count = activitiesCountType,
-                            typesWithSelectedFlag = typesWithSelectedFlag,
-                            eventReceiver = eventReceiver
-                        )
-                    }
-                    EditArtFiltersSectionType.DISTANCE -> distanceTotal?.let {
+                    EditArtFiltersSectionType.DATE -> SectionDate(
+                        count = activitiesCountDate.value,
+                        dateSelections = filterDateSelections,
+                        dateSelectionSelectedIndex = filterDateSelectionIndex.value,
+                        eventReceiver = eventReceiver
+                    )
+                    EditArtFiltersSectionType.ACTIVITY_TYPE -> SectionActivityType(
+                        count = activitiesCountType.value,
+                        typesWithSelectedFlag = typesWithSelectedFlag.toList(),
+                        eventReceiver = eventReceiver
+                    )
+                    EditArtFiltersSectionType.DISTANCE -> distanceTotalEnd.value?.let {
+                        distanceTotalStart.value?.rangeTo(it)
+                    }?.let {
                         SectionDistances(
-                            count = activitiesCountDistance,
-                            distanceSelected = distanceSelected,
+                            count = activitiesCountDistance.value,
+                            distanceSelected = distanceSelectedEnd.value?.let { end ->
+                                distanceSelectedStart.value?.rangeTo(end)
+                            },
                             distanceTotal = it,
-                            distancePendingChangeStart = distancePendingChangeStart,
-                            distancePendingChangeEnd = distancePendingChangeEnd,
+                            distancePendingChangeStart = distancePendingChangeStart.value,
+                            distancePendingChangeEnd = distancePendingChangeEnd.value,
                             eventReceiver = eventReceiver
                         )
                     }

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
@@ -18,31 +20,32 @@ import com.activityartapp.presentation.common.button.Button
 import com.activityartapp.presentation.common.button.ButtonEmphasis
 import com.activityartapp.presentation.common.button.ButtonSize
 import com.activityartapp.presentation.editArtScreen.EditArtViewEvent
+import com.activityartapp.util.enums.BackgroundType
 
 @Composable
 fun EditArtPreview(
-    atLeastOneActivitySelected: Boolean,
-    backgroundIsTransparent: Boolean,
-    bitmap: Bitmap?,
+    atLeastOneActivitySelected: State<Boolean>,
+    backgroundIsTransparent: State<Boolean>,
+    bitmap: State<Bitmap?>,
     eventReceiver: EventReceiver<EditArtViewEvent>
 ) {
-    ScreenBackground {
 
-        if (!atLeastOneActivitySelected) {
+    ScreenBackground {
+        if (!atLeastOneActivitySelected.value) {
             ErrorComposable(
                 header = stringResource(R.string.edit_art_preview_activities_zero_count_header),
                 description = stringResource(R.string.edit_art_preview_activities_zero_count_description),
                 prompt = stringResource(R.string.edit_art_preview_activities_zero_count_prompt)
             )
         } else {
-            bitmap?.let {
+            bitmap.value?.let {
                 Image(
                     bitmap = it.asImageBitmap(),
                     contentDescription = stringResource(R.string.edit_art_preview_image_content_description),
                     modifier = Modifier.weight(1f, false),
                     contentScale = ContentScale.Fit,
                 )
-                if (backgroundIsTransparent) {
+                if (backgroundIsTransparent.value) {
                     Button(
                         emphasis = ButtonEmphasis.LOW,
                         text = "Why is there a checkered pattern?",

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/resize/EditArtResizeScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/resize/EditArtResizeScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.RotateRight
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
@@ -24,8 +26,8 @@ import com.activityartapp.util.ext.toFloatRange
 
 @Composable
 fun EditArtResizeScreen(
-    resolutionList: List<Resolution>,
-    selectedResolutionIndex: Int,
+    resolutionList: SnapshotStateList<Resolution>,
+    selectedResolutionIndex: State<Int>,
     eventReceiver: EventReceiver<EditArtViewEvent>
 ) {
     Section(
@@ -33,7 +35,7 @@ fun EditArtResizeScreen(
         description = stringResource(R.string.edit_art_resize_description),
     ) {
         resolutionList.forEachIndexed { index, res ->
-            val isSelected = selectedResolutionIndex == index
+            val isSelected = selectedResolutionIndex.value == index
             Row(
                 verticalAlignment = Alignment.Top,
                 horizontalArrangement = Arrangement.spacedBy(spacing.medium)

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/sort/EditArtSortScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/sort/EditArtSortScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.RadioButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.stringResource
 import com.activityartapp.R
@@ -18,8 +19,8 @@ import com.activityartapp.util.enums.EditArtSortType
 
 @Composable
 fun ColumnScope.EditArtSortScreen(
-    sortTypeSelected: EditArtSortType,
-    sortDirectionSelected: EditArtSortDirectionType,
+    sortTypeSelected: State<EditArtSortType>,
+    sortDirectionSelected: State<EditArtSortDirectionType>,
     eventReceiver: EventReceiver<EditArtViewEvent>
 ) {
     Section(
@@ -32,7 +33,7 @@ fun ColumnScope.EditArtSortScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 RadioButton(
-                    selected = sortType == sortTypeSelected,
+                    selected = sortType == sortTypeSelected.value,
                     onClick = {
                         eventReceiver.onEvent(
                             EditArtViewEvent.ArtMutatingEvent.SortTypeChanged(
@@ -56,9 +57,9 @@ fun ColumnScope.EditArtSortScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 RadioButtonContentRow(
-                    isSelected = sortDirectionType == sortDirectionSelected,
+                    isSelected = sortDirectionType == sortDirectionSelected.value,
                     text = stringResource(sortDirectionType.headerStrRes),
-                    subtext = stringResource(sortDirectionType.description(sortTypeSelected))
+                    subtext = stringResource(sortDirectionType.description(sortTypeSelected.value))
                 ) {
                     eventReceiver.onEvent(
                         EditArtViewEvent.ArtMutatingEvent.SortDirectionChanged(

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/EditArtStyleScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/EditArtStyleScreen.kt
@@ -15,6 +15,7 @@ import com.activityartapp.presentation.editArtScreen.EditArtViewEvent
 import com.activityartapp.presentation.editArtScreen.StrokeWidthType
 import com.activityartapp.presentation.editArtScreen.composables.Section
 import com.activityartapp.presentation.editArtScreen.subscreens.style.composables.*
+import com.activityartapp.presentation.editArtScreen.subscreens.style.sections.*
 import com.activityartapp.presentation.ui.theme.spacing
 import com.activityartapp.util.enums.AngleType
 import com.activityartapp.util.enums.BackgroundType
@@ -23,6 +24,7 @@ import com.activityartapp.util.enums.BackgroundType
 fun EditArtStyleScreen(
     backgroundType: State<BackgroundType>,
     backgroundGradientAngleType: State<AngleType>,
+    backgroundGradientColorCount: State<Int>,
     colorBackgroundList: SnapshotStateList<ColorWrapper>,
     colorActivities: State<ColorWrapper>,
     colorText: State<ColorWrapper?>,
@@ -52,7 +54,8 @@ fun EditArtStyleScreen(
         items(sections) { section ->
             Section(
                 header = stringResource(section.headerStrRes),
-                description = section.descriptionStrRes?.let { stringResource(it) }
+                description = section.descriptionStrRes?.let { stringResource(it) },
+                excludePadding = section == EditArtStyleSectionType.GRADIENT_COLORS
             ) {
                 when (section) {
                     EditArtStyleSectionType.BACKGROUND_TYPE -> SectionBackgroundType(
@@ -63,11 +66,12 @@ fun EditArtStyleScreen(
                     )
                     EditArtStyleSectionType.GRADIENT_ANGLE -> SectionGradientAngle(
                         angleType = backgroundGradientAngleType.value,
-                        colorList = colorBackgroundList,
+                        colorList = colorBackgroundList.take(backgroundGradientColorCount.value),
                         onGradientAngleTypeChanged = eventReceiver::onEvent
                     )
                     EditArtStyleSectionType.GRADIENT_COLORS -> SectionColorBackgroundGradient(
                         colorList = colorBackgroundList,
+                        colorsCount = backgroundGradientColorCount,
                         onColorChanged = eventReceiver::onEvent,
                         onColorAdded = eventReceiver::onEvent,
                         onColorRemoved = eventReceiver::onEvent,

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/EditArtStyleScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/EditArtStyleScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.res.stringResource
 import com.activityartapp.R
 import com.activityartapp.architecture.EventReceiver
@@ -19,18 +21,18 @@ import com.activityartapp.util.enums.BackgroundType
 
 @Composable
 fun EditArtStyleScreen(
-    backgroundType: BackgroundType,
-    backgroundGradientAngleType: AngleType,
-    colorBackgroundList: List<ColorWrapper>,
-    colorActivities: ColorWrapper,
-    colorText: ColorWrapper?,
+    backgroundType: State<BackgroundType>,
+    backgroundGradientAngleType: State<AngleType>,
+    colorBackgroundList: SnapshotStateList<ColorWrapper>,
+    colorActivities: State<ColorWrapper>,
+    colorText: State<ColorWrapper?>,
     listState: LazyListState,
-    strokeWidthType: StrokeWidthType,
+    strokeWidthType: State<StrokeWidthType>,
     eventReceiver: EventReceiver<EditArtViewEvent>
 ) {
     val sections = mutableListOf<EditArtStyleSectionType>().apply {
         add(EditArtStyleSectionType.BACKGROUND_TYPE)
-        when (backgroundType) {
+        when (backgroundType.value) {
             BackgroundType.GRADIENT -> {
                 add(EditArtStyleSectionType.GRADIENT_ANGLE)
                 add(EditArtStyleSectionType.GRADIENT_COLORS)
@@ -54,13 +56,13 @@ fun EditArtStyleScreen(
             ) {
                 when (section) {
                     EditArtStyleSectionType.BACKGROUND_TYPE -> SectionBackgroundType(
-                        backgroundType = backgroundType,
+                        backgroundType = backgroundType.value,
                         onBackgroundTypeChanged = eventReceiver::onEvent,
                         onClickedInfoGradientBackground = eventReceiver::onEvent,
                         onClickedInfoTransparentBackground = eventReceiver::onEvent
                     )
                     EditArtStyleSectionType.GRADIENT_ANGLE -> SectionGradientAngle(
-                        angleType = backgroundGradientAngleType,
+                        angleType = backgroundGradientAngleType.value,
                         colorList = colorBackgroundList,
                         onGradientAngleTypeChanged = eventReceiver::onEvent
                     )
@@ -79,21 +81,21 @@ fun EditArtStyleScreen(
                         onColorPendingChanged = eventReceiver::onEvent
                     )
                     EditArtStyleSectionType.ACTIVITIES_COLOR -> SectionColorActivities(
-                        color = colorActivities,
+                        color = colorActivities.value,
                         onColorChanged = eventReceiver::onEvent,
                         onColorPendingChanged = eventReceiver::onEvent,
                         onColorPendingChangeConfirmed = eventReceiver::onEvent
                     )
                     EditArtStyleSectionType.FONT_COLOR -> SectionColorText(
-                        color = colorText,
-                        colorActivities = colorActivities,
+                        color = colorText.value,
+                        colorActivities = colorActivities.value,
                         onColorChanged = eventReceiver::onEvent,
                         onUseFontChanged = eventReceiver::onEvent,
                         onColorPendingChanged = eventReceiver::onEvent,
                         onColorPendingChangeConfirmed = eventReceiver::onEvent
                     )
                     EditArtStyleSectionType.ACTIVITY_WEIGHT -> SectionActivityWidth(
-                        strokeWidthType = strokeWidthType,
+                        strokeWidthType = strokeWidthType.value,
                         onStyleStrokeWidthChanged = eventReceiver::onEvent
                     )
                 }

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionColorActivities.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionColorActivities.kt
@@ -1,14 +1,14 @@
-package com.activityartapp.presentation.editArtScreen.subscreens.style.composables
+package com.activityartapp.presentation.editArtScreen.subscreens.style.sections
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.res.stringResource
-import com.activityartapp.R
+import androidx.compose.runtime.State
 import com.activityartapp.presentation.editArtScreen.ColorWrapper
 import com.activityartapp.presentation.editArtScreen.EditArtViewEvent.ArtMutatingEvent.StyleColorChanged
 import com.activityartapp.presentation.editArtScreen.EditArtViewEvent.ArtMutatingEvent.StyleColorPendingChangeConfirmed
 import com.activityartapp.presentation.editArtScreen.EditArtViewEvent.StyleColorPendingChanged
 import com.activityartapp.presentation.editArtScreen.StyleIdentifier
-import com.activityartapp.presentation.editArtScreen.composables.Section
+import com.activityartapp.presentation.editArtScreen.subscreens.style.composables.ColorPreview
+import com.activityartapp.presentation.editArtScreen.subscreens.style.composables.ColorSlidersRGB
 
 @Composable
 fun SectionColorActivities(

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionColorBackgroundGradient.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionColorBackgroundGradient.kt
@@ -1,18 +1,21 @@
-package com.activityartapp.presentation.editArtScreen.subscreens.style.composables
+package com.activityartapp.presentation.editArtScreen.subscreens.style.sections
 
-import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Card
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.activityartapp.R
 import com.activityartapp.presentation.common.button.Button
@@ -25,80 +28,60 @@ import com.activityartapp.presentation.editArtScreen.EditArtViewEvent.ClickedRem
 import com.activityartapp.presentation.editArtScreen.EditArtViewEvent.StyleColorPendingChanged
 import com.activityartapp.presentation.editArtScreen.EditArtViewState
 import com.activityartapp.presentation.editArtScreen.StyleIdentifier
+import com.activityartapp.presentation.editArtScreen.subscreens.style.composables.ColorPreview
+import com.activityartapp.presentation.editArtScreen.subscreens.style.composables.ColorSlidersRGB
 import com.activityartapp.presentation.ui.theme.spacing
+import kotlinx.coroutines.launch
 
 @Composable
 fun SectionColorBackgroundGradient(
     colorList: List<ColorWrapper>,
+    colorsCount: State<Int>,
     onColorChanged: (StyleColorChanged) -> Unit,
     onColorAdded: (StyleBackgroundColorAdded) -> Unit,
     onColorRemoved: (ClickedRemoveGradientColor) -> Unit,
     onColorPendingChangeConfirmed: (StyleColorPendingChangeConfirmed) -> Unit,
     onColorPendingChanged: (StyleColorPendingChanged) -> Unit
 ) {
-    colorList.forEachIndexed { index, color ->
-        Card(
-            border = BorderStroke(
-                width = 1.dp,
-                color = MaterialTheme.colors.background
-            )
-        ) {
-            ColumnMediumSpacing(modifier = Modifier.padding(spacing.small)) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(spacing.medium),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    ColorPreview(
-                        colorWrapper = color,
-                        modifier = Modifier.weight(1f, true)
-                    )
-                    // For an unknown reason, if this event is not defined
-                    // before than a runtime crash occurs
-                    val event = ClickedRemoveGradientColor(index)
-                    if (colorList.size > EditArtViewState.MIN_GRADIENT_BG_COLORS) {
-                        IconButton(onClick = { onColorRemoved(event) }) {
-                            Icon(imageVector = Icons.Outlined.Delete, null)
-                        }
-                    }
+    val lazyListState = rememberLazyListState()
+    val scope = rememberCoroutineScope()
+    LazyRow(
+        state = lazyListState,
+        modifier = Modifier
+            .padding(
+                bottom = if ((colorsCount.value >= EditArtViewState.MAX_GRADIENT_BG_COLORS)) {
+                    spacing.medium
+                } else {
+                    0.dp
                 }
-                ColorSlidersRGB(
-                    color = color,
-                    onColorChanged = { colorType, changedTo ->
-                        onColorChanged(
-                            StyleColorChanged(
-                                style = StyleIdentifier.Background(index = index),
-                                colorType = colorType,
-                                changedTo = changedTo
-                            )
-                        )
-                    },
-                    onColorPendingChanged = { colorType, changedTo ->
-                        onColorPendingChanged(
-                            StyleColorPendingChanged(
-                                style = StyleIdentifier.Background(index = index),
-                                colorType = colorType,
-                                changedTo = changedTo
-                            )
-                        )
-                    },
-                    onColorPendingChangeConfirmed = {
-                        onColorPendingChangeConfirmed(
-                            StyleColorPendingChangeConfirmed(
-                                style = StyleIdentifier.Background(index = index),
-                            )
-                        )
-                    }
-                )
-            }
-        }
-    }
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.End,
-        verticalArrangement = Arrangement.spacedBy(spacing.small)
+            )
+            .background(MaterialTheme.colors.background)
+            .padding(vertical = spacing.xSmall),
+        horizontalArrangement = Arrangement.spacedBy(spacing.xSmall)
     ) {
-        if (colorList.size < EditArtViewState.MAX_GRADIENT_BG_COLORS) {
+        item { Spacer(modifier = Modifier.width(spacing.xSmall)) }
+        items(colorsCount.value) {
+            val color = colorList[it]
+            ListItem(
+                index = it,
+                color = color,
+                colorsCount = colorsCount.value,
+                onColorChanged = onColorChanged,
+                onColorRemoved = onColorRemoved,
+                onColorPendingChangeConfirmed = onColorPendingChangeConfirmed,
+                onColorPendingChanged = onColorPendingChanged
+            )
+        }
+        item { Spacer(modifier = Modifier.width(spacing.xSmall)) }
+    }
+
+    if (colorsCount.value < EditArtViewState.MAX_GRADIENT_BG_COLORS) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = spacing.medium, end = spacing.medium),
+            horizontalAlignment = Alignment.End,
+        ) {
             Button(
                 emphasis = ButtonEmphasis.HIGH,
                 size = ButtonSize.MEDIUM,
@@ -106,8 +89,83 @@ fun SectionColorBackgroundGradient(
                 leadingIcon = Icons.Outlined.Add,
                 leadingIconContentDescription = stringResource(R.string.edit_art_style_background_gradient_add_color_button_cd)
             ) {
+                scope.launch {
+                    lazyListState.animateScrollToItem(colorsCount.value - 1)
+                }
                 onColorAdded(StyleBackgroundColorAdded)
             }
+        }
+    }
+}
+
+@Composable
+private fun ListItem(
+    index: Int,
+    color: ColorWrapper,
+    colorsCount: Int,
+    onColorChanged: (StyleColorChanged) -> Unit,
+    onColorRemoved: (ClickedRemoveGradientColor) -> Unit,
+    onColorPendingChangeConfirmed: (StyleColorPendingChangeConfirmed) -> Unit,
+    onColorPendingChanged: (StyleColorPendingChanged) -> Unit
+) {
+    Card {
+        ColumnMediumSpacing(
+            modifier = Modifier
+                .width(360.dp)
+                .padding(spacing.small)
+        ) {
+            Text(
+                text = "Color ${index + 1}",
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.subtitle1
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(spacing.medium),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                ColorPreview(
+                    colorWrapper = color,
+                    modifier = Modifier.weight(1f, true)
+                )
+                // For an unknown reason, if this event is not defined
+                // before than a runtime crash occurs
+                val event = ClickedRemoveGradientColor(index)
+                if (colorsCount > EditArtViewState.MIN_GRADIENT_BG_COLORS) {
+                    IconButton(onClick = { onColorRemoved(event) }) {
+                        Icon(imageVector = Icons.Outlined.Delete, null)
+                    }
+                }
+            }
+            ColorSlidersRGB(
+                color = color,
+                onColorChanged = { colorType, changedTo ->
+                    onColorChanged(
+                        StyleColorChanged(
+                            style = StyleIdentifier.Background(index = index),
+                            colorType = colorType,
+                            changedTo = changedTo
+                        )
+                    )
+                },
+                onColorPendingChanged = { colorType, changedTo ->
+                    onColorPendingChanged(
+                        StyleColorPendingChanged(
+                            style = StyleIdentifier.Background(index = index),
+                            colorType = colorType,
+                            changedTo = changedTo
+                        )
+                    )
+                },
+                onColorPendingChangeConfirmed = {
+                    onColorPendingChangeConfirmed(
+                        StyleColorPendingChangeConfirmed(
+                            style = StyleIdentifier.Background(index = index),
+                        )
+                    )
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionColorBackgroundGradient.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionColorBackgroundGradient.kt
@@ -31,6 +31,7 @@ import com.activityartapp.presentation.editArtScreen.StyleIdentifier
 import com.activityartapp.presentation.editArtScreen.subscreens.style.composables.ColorPreview
 import com.activityartapp.presentation.editArtScreen.subscreens.style.composables.ColorSlidersRGB
 import com.activityartapp.presentation.ui.theme.spacing
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
@@ -44,7 +45,6 @@ fun SectionColorBackgroundGradient(
     onColorPendingChanged: (StyleColorPendingChanged) -> Unit
 ) {
     val lazyListState = rememberLazyListState()
-    val scope = rememberCoroutineScope()
     LazyRow(
         state = lazyListState,
         modifier = Modifier
@@ -89,9 +89,6 @@ fun SectionColorBackgroundGradient(
                 leadingIcon = Icons.Outlined.Add,
                 leadingIconContentDescription = stringResource(R.string.edit_art_style_background_gradient_add_color_button_cd)
             ) {
-                scope.launch {
-                    lazyListState.animateScrollToItem(colorsCount.value - 1)
-                }
                 onColorAdded(StyleBackgroundColorAdded)
             }
         }
@@ -115,14 +112,12 @@ private fun ListItem(
                 .padding(spacing.small)
         ) {
             Text(
-                text = "Color ${index + 1}",
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.subtitle1
+                text = "COLOR ${index + 1} / $colorsCount",
+                style = MaterialTheme.typography.overline
             )
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(spacing.medium),
+                horizontalArrangement = Arrangement.spacedBy(spacing.small),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 ColorPreview(

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionColorBackgroundGradient.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionColorBackgroundGradient.kt
@@ -112,8 +112,8 @@ private fun ListItem(
                 .padding(spacing.small)
         ) {
             Text(
-                text = "COLOR ${index + 1} / $colorsCount",
-                style = MaterialTheme.typography.overline
+                text = "${index + 1} / $colorsCount",
+                style = MaterialTheme.typography.subtitle1
             )
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionColorBackgroundSolid.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionColorBackgroundSolid.kt
@@ -1,15 +1,13 @@
-package com.activityartapp.presentation.editArtScreen.subscreens.style.composables
+package com.activityartapp.presentation.editArtScreen.subscreens.style.sections
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.res.stringResource
-import com.activityartapp.R
 import com.activityartapp.presentation.editArtScreen.ColorWrapper
 import com.activityartapp.presentation.editArtScreen.EditArtViewEvent.ArtMutatingEvent.StyleColorChanged
 import com.activityartapp.presentation.editArtScreen.EditArtViewEvent.ArtMutatingEvent.StyleColorPendingChangeConfirmed
 import com.activityartapp.presentation.editArtScreen.EditArtViewEvent.StyleColorPendingChanged
 import com.activityartapp.presentation.editArtScreen.StyleIdentifier
-import com.activityartapp.presentation.editArtScreen.composables.Section
-import com.activityartapp.util.enums.BackgroundType
+import com.activityartapp.presentation.editArtScreen.subscreens.style.composables.ColorPreview
+import com.activityartapp.presentation.editArtScreen.subscreens.style.composables.ColorSlidersRGB
 
 @Composable
 fun SectionColorBackgroundSolid(

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionColorText.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionColorText.kt
@@ -1,4 +1,4 @@
-package com.activityartapp.presentation.editArtScreen.subscreens.style.composables
+package com.activityartapp.presentation.editArtScreen.subscreens.style.sections
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
@@ -9,7 +9,8 @@ import com.activityartapp.presentation.editArtScreen.EditArtViewEvent.ArtMutatin
 import com.activityartapp.presentation.editArtScreen.EditArtViewEvent.StyleColorPendingChanged
 import com.activityartapp.presentation.editArtScreen.StyleIdentifier
 import com.activityartapp.presentation.editArtScreen.composables.RadioButtonContentRow
-import com.activityartapp.presentation.editArtScreen.composables.Section
+import com.activityartapp.presentation.editArtScreen.subscreens.style.composables.ColorPreview
+import com.activityartapp.presentation.editArtScreen.subscreens.style.composables.ColorSlidersRGB
 
 @Composable
 fun SectionColorText(

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionGradientAngle.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionGradientAngle.kt
@@ -1,4 +1,4 @@
-package com.activityartapp.presentation.editArtScreen.subscreens.style.composables
+package com.activityartapp.presentation.editArtScreen.subscreens.style.sections
 
 import android.util.Size
 import androidx.compose.foundation.Canvas

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/type/EditArtTypeScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/type/EditArtTypeScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.*
 import com.activityartapp.R
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -30,18 +31,18 @@ import kotlin.math.roundToInt
 
 @Composable
 fun EditArtTypeScreen(
-    activitiesDistanceMetersSummed: Int,
-    customTextCenter: String,
-    customTextLeft: String,
-    customTextRight: String,
-    fontSelected: FontType,
-    fontWeightSelected: FontWeightType,
-    fontItalicized: Boolean,
-    fontSizeSelected: FontSizeType,
+    activitiesDistanceMetersSummed: State<Int>,
+    customTextCenter: State<String>,
+    customTextLeft: State<String>,
+    customTextRight: State<String>,
+    fontSelected: State<FontType>,
+    fontWeightSelected: State<FontWeightType>,
+    fontItalicized: State<Boolean>,
+    fontSizeSelected: State<FontSizeType>,
     maximumCustomTextLength: Int,
-    selectedEditArtTypeTypeCenter: EditArtTypeType,
-    selectedEditArtTypeTypeLeft: EditArtTypeType,
-    selectedEditArtTypeTypeRight: EditArtTypeType,
+    selectedEditArtTypeTypeCenter: State<EditArtTypeType>,
+    selectedEditArtTypeTypeLeft: State<EditArtTypeType>,
+    selectedEditArtTypeTypeRight: State<EditArtTypeType>,
     eventReceiver: EventReceiver<EditArtViewEvent>
 ) {
     val focusManager = LocalFocusManager.current
@@ -55,18 +56,18 @@ fun EditArtTypeScreen(
             EditArtTypeType.values().forEach { type ->
                 RadioButtonContentRow(
                     isSelected = type == when (section) {
-                        EditArtTypeSection.LEFT -> selectedEditArtTypeTypeLeft
-                        EditArtTypeSection.CENTER -> selectedEditArtTypeTypeCenter
-                        EditArtTypeSection.RIGHT -> selectedEditArtTypeTypeRight
+                        EditArtTypeSection.LEFT -> selectedEditArtTypeTypeLeft.value
+                        EditArtTypeSection.CENTER -> selectedEditArtTypeTypeCenter.value
+                        EditArtTypeSection.RIGHT -> selectedEditArtTypeTypeRight.value
                     },
                     content = type.takeIf { it == EditArtTypeType.CUSTOM }?.let {
                         {
                             ColumnSmallSpacing(horizontalAlignment = Alignment.Start) {
                                 OutlinedTextField(
                                     value = when (section) {
-                                        EditArtTypeSection.LEFT -> customTextLeft
-                                        EditArtTypeSection.CENTER -> customTextCenter
-                                        EditArtTypeSection.RIGHT -> customTextRight
+                                        EditArtTypeSection.LEFT -> customTextLeft.value
+                                        EditArtTypeSection.CENTER -> customTextCenter.value
+                                        EditArtTypeSection.RIGHT -> customTextRight.value
                                     },
                                     onValueChange = {
                                         eventReceiver.onEvent(
@@ -91,9 +92,9 @@ fun EditArtTypeScreen(
                                 Text(
                                     text = "${
                                         when (section) {
-                                            EditArtTypeSection.LEFT -> customTextLeft.length
-                                            EditArtTypeSection.CENTER -> customTextCenter.length
-                                            EditArtTypeSection.RIGHT -> customTextRight.length
+                                            EditArtTypeSection.LEFT -> customTextLeft.value.length
+                                            EditArtTypeSection.CENTER -> customTextCenter.value.length
+                                            EditArtTypeSection.RIGHT -> customTextRight.value.length
                                         }
                                     } / $maximumCustomTextLength",
                                     style = MaterialTheme.typography.caption
@@ -103,8 +104,8 @@ fun EditArtTypeScreen(
                     },
                     text = stringResource(type.header),
                     subtext = when (type) {
-                        EditArtTypeType.DISTANCE_MILES -> activitiesDistanceMetersSummed.meterToMilesStr()
-                        EditArtTypeType.DISTANCE_KILOMETERS -> activitiesDistanceMetersSummed.meterToKilometerStr()
+                        EditArtTypeType.DISTANCE_MILES -> activitiesDistanceMetersSummed.value.meterToMilesStr()
+                        EditArtTypeType.DISTANCE_KILOMETERS -> activitiesDistanceMetersSummed.value.meterToKilometerStr()
                         else -> null
                     }
                 ) {
@@ -128,7 +129,7 @@ fun EditArtTypeScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 RadioButton(
-                    selected = it == fontSelected,
+                    selected = it == fontSelected.value,
                     onClick = { eventReceiver.onEvent(TypeFontChanged(changedTo = it)) }
                 )
                 Text(
@@ -146,23 +147,23 @@ fun EditArtTypeScreen(
             }
         }
     }
-    if (fontSelected.fontWeightTypes.containsMultipleTypes) {
+    if (fontSelected.value.fontWeightTypes.containsMultipleTypes) {
         Section(
             header = stringResource(R.string.edit_art_type_font_weight_header),
             description = stringResource(R.string.edit_art_type_font_weight_description)
         ) {
-            fontSelected.fontWeightTypes.forEach {
+            fontSelected.value.fontWeightTypes.forEach {
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(spacing.medium),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     RadioButtonContentRow(
-                        isSelected = fontWeightSelected == it,
+                        isSelected = fontWeightSelected.value == it,
                         text = stringResource(it.stringRes),
                         fontFamily = FontFamily(
                             Typeface.createFromAsset(
                                 context.assets,
-                                fontSelected.getAssetPath(it)
+                                fontSelected.value.getAssetPath(it)
                             )
                         )
                     ) { eventReceiver.onEvent(TypeFontWeightChanged(changedTo = it)) }
@@ -170,7 +171,7 @@ fun EditArtTypeScreen(
             }
         }
     }
-    if (fontSelected.isItalic) {
+    if (fontSelected.value.isItalic) {
         Section(
             header = stringResource(R.string.edit_art_type_font_italic_header),
             description = stringResource(R.string.edit_art_type_font_italic_description)
@@ -179,12 +180,12 @@ fun EditArtTypeScreen(
                 horizontalArrangement = Arrangement.spacedBy(spacing.medium),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Switch(checked = fontItalicized, onCheckedChange = {
+                Switch(checked = fontItalicized.value, onCheckedChange = {
                     eventReceiver.onEvent(TypeFontItalicChanged(changedTo = it))
                 })
                 Text(
                     text = stringResource(
-                        if (fontItalicized) {
+                        if (fontItalicized.value) {
                             R.string.edit_art_type_font_italic_enabled
                         } else {
                             R.string.edit_art_type_font_italic_disabled
@@ -193,7 +194,7 @@ fun EditArtTypeScreen(
                     fontFamily = FontFamily(
                         Typeface.createFromAsset(
                             context.assets,
-                            fontSelected.getAssetPath(fontWeightSelected, fontItalicized)
+                            fontSelected.value.getAssetPath(fontWeightSelected.value, fontItalicized.value)
                         )
                     )
                 )
@@ -211,7 +212,7 @@ fun EditArtTypeScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 RadioButtonContentRow(
-                    isSelected = fontSizeSelected == it,
+                    isSelected = fontSizeSelected.value == it,
                     text = stringResource(it.strRes)
                 ) {
                     eventReceiver.onEvent(

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         kotlin_version = '1.7.20'
-        compose_version = '1.3.2'
+        compose_version = '1.4.0-beta02'
         firebase_version = '4.3.14'
     }
     repositories {


### PR DESCRIPTION
* Refactors EditArt screen models to no longer be based around copying an entire data class of raw values (int, float, ColorWrapper, etc). Instead, it will be a data class consisting of State references to private MutableState values.
* Dramatically improve the performance of sliders in Gradient Colors and Filters Distances.
* Increment build for release.