### PR TITLE
Improve the performance of the Resize screen by limiting recomposition

### DIFF
--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
@@ -338,7 +338,7 @@ enum class StrokeWidthType(val headerId: Int) {
     THICK(R.string.edit_art_style_stroke_thick);
 }
 
-
+@Stable
 sealed interface Resolution : Parcelable {
 
     val widthPx: Int
@@ -348,6 +348,7 @@ sealed interface Resolution : Parcelable {
     @Composable
     fun displayTextResolution(): String
 
+    @Stable
     interface RotatingResolution : Resolution {
         val isRotated: Boolean
         val swappingChangesSize: Boolean
@@ -374,6 +375,7 @@ sealed interface Resolution : Parcelable {
     }
 
     @Parcelize
+    @Stable
     data class ComputerResolution(
         override val stringResourceId: Int,
         override val origWidthPx: Int,
@@ -423,13 +425,14 @@ sealed interface Resolution : Parcelable {
     }
 
     @Parcelize
+    @Stable
     data class CustomResolution(
         override val widthPx: Int,
         override val heightPx: Int,
         private val sizeMaximumPx: Int,
         private val sizeMinimumPx: Int,
-        @IgnoredOnParcel var pendingWidth: String? = null,
-        @IgnoredOnParcel var pendingHeight: String? = null
+        @IgnoredOnParcel val pendingWidth: String? = null,
+        @IgnoredOnParcel val pendingHeight: String? = null
     ) : Resolution {
 
         @IgnoredOnParcel

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
@@ -100,10 +100,9 @@ fun EditArtViewDelegate(viewModel: EditArtViewModel) {
                         scrollState = when (it) {
                             TYPE -> scrollStateType
                             SORT -> scrollStateSort
-                            RESIZE -> scrollStateResize
                             else -> null
                         },
-                        scrollingEnabled = it != PREVIEW && it != STYLE && it != FILTERS
+                        scrollingEnabled = it != PREVIEW && it != STYLE && it != FILTERS && it != RESIZE
                     ) {
                         when (it) {
                             PREVIEW -> EditArtPreview(

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
@@ -250,6 +250,7 @@ class EditArtViewModel @Inject constructor(
     private val _styleBackgroundList = (0 until 7).map {
         if (it % 2 == 0) ColorWrapper.Black else ColorWrapper.White
     }.toMutableStateList()
+
     private val _styleBackgroundAngleType = mutableStateOf(AngleType.CW90)
     private val _styleBackgroundGradientColorCount = mutableStateOf(2)
     private val _styleBackgroundType = mutableStateOf(BackgroundType.SOLID)

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/composables/TextFieldSliders.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/composables/TextFieldSliders.kt
@@ -1,6 +1,5 @@
 package com.activityartapp.presentation.editArtScreen.composables
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardActions
@@ -13,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/resize/EditArtResizeScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/resize/EditArtResizeScreen.kt
@@ -2,6 +2,9 @@ package com.activityartapp.presentation.editArtScreen.subscreens.resize
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.RotateRight
@@ -34,99 +37,159 @@ fun EditArtResizeScreen(
         header = stringResource(R.string.edit_art_resize_header),
         description = stringResource(R.string.edit_art_resize_description),
     ) {
-        resolutionList.forEachIndexed { index, res ->
-            val isSelected = selectedResolutionIndex.value == index
-            Row(
-                verticalAlignment = Alignment.Top,
-                horizontalArrangement = Arrangement.spacedBy(spacing.medium)
-            ) {
-                RadioButtonContentRow(
-                    actionButtonContent = (res as? RotatingResolution)
-                        ?.takeIf { it.swappingChangesSize }
-                        ?.let {
-                            {
-                                Icon(
-                                    imageVector = Icons.Default.RotateRight,
-                                    contentDescription = stringResource(R.string.edit_art_resize_rotate_right_content_description)
-                                )
-                            }
-                        },
-                    content = (res as? Resolution.CustomResolution)?.let {
-                        {
-                            val range = it.sizeRangePx.toFloatRange()
-                            val onTextFieldDone = {
-                                eventReceiver.onEvent(
-                                    SizeCustomPendingChangeConfirmed(customIndex = index)
-                                )
-                            }
-                            TextFieldSliders(
-                                specifications = listOf(
-                                    TextFieldSliderSpecification(
-                                        pendingChangesMessage = it.pendingWidth?.let {
-                                            stringResource(R.string.edit_art_resize_custom_pending_change_prompt)
-                                        },
-                                        keyboardType = KeyboardType.Number,
-                                        textFieldLabel = stringResource(R.string.edit_art_resize_pixels_width),
-                                        textFieldValue = it.pendingWidth
-                                            ?: it.widthPx.toString(),
-                                        sliderValue = it.widthPx.toFloat(),
-                                        sliderRange = range,
-                                        onSliderChanged = {
-                                            eventReceiver.onEvent(
-                                                SizeCustomChanged(
-                                                    customIndex = index,
-                                                    changedToPx = it.toInt(),
-                                                    heightChanged = false
-                                                )
-                                            )
-                                        },
-                                        onTextFieldChanged = { str ->
-                                            eventReceiver.onEvent(
-                                                EditArtViewEvent.SizeCustomPendingChanged.WidthChanged(
-                                                    changedTo = str
-                                                )
-                                            )
-                                        },
-                                        onTextFieldDone = onTextFieldDone
-                                    ),
-                                    TextFieldSliderSpecification(
-                                        pendingChangesMessage = it.pendingHeight?.let {
-                                            stringResource(R.string.edit_art_resize_custom_pending_change_prompt)
-                                        },
-                                        keyboardType = KeyboardType.Number,
-                                        textFieldLabel = stringResource(R.string.edit_art_resize_pixels_height),
-                                        textFieldValue = it.pendingHeight
-                                            ?: it.heightPx.toString(),
-                                        sliderValue = it.heightPx.toFloat(),
-                                        sliderRange = range,
-                                        onSliderChanged = {
-                                            eventReceiver.onEvent(
-                                                SizeCustomChanged(
-                                                    customIndex = index,
-                                                    changedToPx = it.toInt(),
-                                                    heightChanged = true
-                                                )
-                                            )
-                                        },
-                                        onTextFieldChanged = { str ->
-                                            eventReceiver.onEvent(
-                                                EditArtViewEvent.SizeCustomPendingChanged.HeightChanged(
-                                                    changedTo = str
-                                                )
-                                            )
-                                        },
-                                        onTextFieldDone = onTextFieldDone
-                                    )
-                                )
+        ResolutionLazyList(
+            selectedResolutionIndex = selectedResolutionIndex.value,
+            resolutionList = resolutionList,
+            onSizeRotated = eventReceiver::onEvent,
+            onSizeChanged = eventReceiver::onEvent,
+            onSizeCustomChanged = eventReceiver::onEvent,
+            onSizeCustomPendingChangeConfirmed = eventReceiver::onEvent,
+            onSizeCustomPendingHeightChanged = eventReceiver::onEvent,
+            onSizeCustomPendingWidthChanged = eventReceiver::onEvent
+        )
+    }
+}
+
+@Composable
+private fun ResolutionLazyList(
+    selectedResolutionIndex: Int,
+    resolutionList: List<Resolution>,
+    onSizeRotated: (SizeRotated) -> Unit,
+    onSizeCustomPendingChangeConfirmed: (SizeCustomPendingChangeConfirmed) -> Unit,
+    onSizeCustomChanged: (SizeCustomChanged) -> Unit,
+    onSizeCustomPendingWidthChanged: (EditArtViewEvent.SizeCustomPendingChanged.WidthChanged) -> Unit,
+    onSizeCustomPendingHeightChanged: (EditArtViewEvent.SizeCustomPendingChanged.HeightChanged) -> Unit,
+    onSizeChanged: (SizeChanged) -> Unit
+) {
+    val lazyListState = rememberLazyListState()
+    LazyColumn(
+        state = lazyListState,
+        verticalArrangement = Arrangement.spacedBy(spacing.medium)
+    ) {
+        itemsIndexed(resolutionList) { index, resolution ->
+            ListItem(
+                isSelected = selectedResolutionIndex == index,
+                index = index,
+                res = resolution,
+                onSizeRotated,
+                onSizeCustomPendingChangeConfirmed,
+                onSizeCustomChanged,
+                onSizeCustomPendingWidthChanged,
+                onSizeCustomPendingHeightChanged,
+                onSizeChanged
+            )
+        }
+    }
+
+}
+
+@Composable
+private fun ListItem(
+    isSelected: Boolean,
+    index: Int,
+    res: Resolution,
+    onSizeRotated: (SizeRotated) -> Unit,
+    onSizeCustomPendingChangeConfirmed: (SizeCustomPendingChangeConfirmed) -> Unit,
+    onSizeCustomChanged: (SizeCustomChanged) -> Unit,
+    onSizeCustomPendingWidthChanged: (EditArtViewEvent.SizeCustomPendingChanged.WidthChanged) -> Unit,
+    onSizeCustomPendingHeightChanged: (EditArtViewEvent.SizeCustomPendingChanged.HeightChanged) -> Unit,
+    onSizeChanged: (SizeChanged) -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(spacing.medium)
+    ) {
+        RadioButtonContentRow(
+            actionButtonContent = (res as? RotatingResolution)
+                ?.takeIf { it.swappingChangesSize }
+                ?.let {
+                    {
+                        Icon(
+                            imageVector = Icons.Default.RotateRight,
+                            contentDescription = stringResource(R.string.edit_art_resize_rotate_right_content_description)
+                        )
+                    }
+                },
+            content = (res as? Resolution.CustomResolution)?.let {
+                {
+                    val range = it.sizeRangePx.toFloatRange()
+                    val onTextFieldDone = {
+                        onSizeCustomPendingChangeConfirmed(
+                            SizeCustomPendingChangeConfirmed(
+                                customIndex = index
                             )
-                        }
-                    },
-                    onActionButtonPressed = { eventReceiver.onEvent(SizeRotated(index)) },
-                    isSelected = isSelected,
-                    text = res.displayTextResolution(),
-                    subtext = (res as? RotatingResolution)?.displayTextPixels()
-                ) { eventReceiver.onEvent(SizeChanged(index)) }
-            }
+                        )
+                    }
+                    TextFieldSliders(
+                        specifications = listOf(
+                            TextFieldSliderSpecification(
+                                pendingChangesMessage = it.pendingWidth?.let {
+                                    stringResource(R.string.edit_art_resize_custom_pending_change_prompt)
+                                },
+                                keyboardType = KeyboardType.Number,
+                                textFieldLabel = stringResource(R.string.edit_art_resize_pixels_width),
+                                textFieldValue = it.pendingWidth
+                                    ?: it.widthPx.toString(),
+                                sliderValue = it.widthPx.toFloat(),
+                                sliderRange = range,
+                                onSliderChanged = {
+                                    onSizeCustomChanged(
+                                        SizeCustomChanged(
+                                            customIndex = index,
+                                            changedToPx = it.toInt(),
+                                            heightChanged = false
+                                        )
+                                    )
+                                },
+                                onTextFieldChanged = { str ->
+                                    onSizeCustomPendingWidthChanged(
+                                        EditArtViewEvent.SizeCustomPendingChanged.WidthChanged(
+                                            changedTo = str
+                                        )
+                                    )
+                                },
+                                onTextFieldDone = onTextFieldDone
+                            ),
+                            TextFieldSliderSpecification(
+                                pendingChangesMessage = it.pendingHeight?.let {
+                                    stringResource(R.string.edit_art_resize_custom_pending_change_prompt)
+                                },
+                                keyboardType = KeyboardType.Number,
+                                textFieldLabel = stringResource(R.string.edit_art_resize_pixels_height),
+                                textFieldValue = it.pendingHeight
+                                    ?: it.heightPx.toString(),
+                                sliderValue = it.heightPx.toFloat(),
+                                sliderRange = range,
+                                onSliderChanged = {
+                                    onSizeCustomChanged(
+                                        SizeCustomChanged(
+                                            customIndex = index,
+                                            changedToPx = it.toInt(),
+                                            heightChanged = true
+                                        )
+                                    )
+                                },
+                                onTextFieldChanged = { str ->
+                                    onSizeCustomPendingHeightChanged(
+                                        EditArtViewEvent.SizeCustomPendingChanged.HeightChanged(
+                                            changedTo = str
+                                        )
+                                    )
+                                },
+                                onTextFieldDone = onTextFieldDone
+                            )
+                        )
+                    )
+                }
+            },
+            onActionButtonPressed = {
+                onSizeRotated(SizeRotated(rotatedIndex = index))
+            },
+            isSelected = isSelected,
+            text = res.displayTextResolution(),
+            subtext = (res as? RotatingResolution)?.displayTextPixels()
+        ) {
+            onSizeChanged(SizeChanged(changedIndex = index))
         }
     }
 }

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionBackgroundType.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionBackgroundType.kt
@@ -1,8 +1,7 @@
-package com.activityartapp.presentation.editArtScreen.subscreens.style.composables
+package com.activityartapp.presentation.editArtScreen.subscreens.style.sections
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import com.activityartapp.presentation.editArtScreen.EditArtViewEvent
 import com.activityartapp.presentation.editArtScreen.composables.RadioButtonContentRow
 import com.activityartapp.presentation.editArtScreen.EditArtViewEvent.ClickedInfoTransparentBackground
 import com.activityartapp.presentation.editArtScreen.EditArtViewEvent.ClickedInfoGradientBackground


### PR DESCRIPTION
* This commit dramatically improves the performance of the resize screen, particularly notable when dragging the custom resolution sliders.
* This previously recomposed the entire resize list. Now, it only recomposes that element.
* This could be improved further because as of this commit, both text sliders recompose when one is changed when only one needs to.
