### PR TITLE
Improve performance of FILTERS date view events by limiting recomposition

### DIFF
--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
@@ -295,14 +295,18 @@ data class ColorWrapper(
     fun alphaToEightBitString() = ratioToEightBit(alpha).toString()
 }
 
+@Stable
 sealed interface DateSelection : Parcelable {
     @Parcelize
+    @Stable
     object All : DateSelection
 
     @Parcelize
+    @Stable
     data class Year(val year: Int) : DateSelection
 
     @Parcelize
+    @Stable
     data class Custom(
         val dateSelectedStartUnixMs: Long,
         val dateSelectedEndUnixMs: Long,

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
@@ -158,9 +158,12 @@ class EditArtViewModel @Inject constructor(
                             .takeIf { prevIndex -> prevIndex in INDEX_FIRST..it.lastIndex }
                             ?: INDEX_FIRST
                     }
-                _filterDateSelections.clear()
                 if (selections != null) {
-                    _filterDateSelections.addAll(selections)
+                    val difference = selections.subtract(_filterDateSelections)
+                    _filterDateSelections.removeIf { !selections.contains(it) }
+                    _filterDateSelections.addAll(difference)
+                } else {
+                    _filterDateSelections.clear()
                 }
                 _filterDateSelectionIndex.value = selectionIndex
             }

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/filters/EditArtFiltersScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/filters/EditArtFiltersScreen.kt
@@ -44,7 +44,7 @@ fun EditArtFiltersScreen(
         if (typesWithSelectedFlag.isNotEmpty()) {
             add(EditArtFiltersSectionType.ACTIVITY_TYPE)
         }
-        if (distanceTotalStart.value != null) { // todo add back start != end case
+        if (distanceTotalStart.value != null) { // todo add back start != end case reminder
             add(EditArtFiltersSectionType.DISTANCE)
         }
     }
@@ -59,9 +59,9 @@ fun EditArtFiltersScreen(
             ) {
                 when (section) {
                     EditArtFiltersSectionType.DATE -> SectionDate(
-                        count = activitiesCountDate.value,
+                        count = activitiesCountDate,
                         dateSelections = filterDateSelections,
-                        dateSelectionSelectedIndex = filterDateSelectionIndex.value,
+                        dateSelectionSelectedIndex = filterDateSelectionIndex,
                         eventReceiver = eventReceiver
                     )
                     EditArtFiltersSectionType.ACTIVITY_TYPE -> SectionActivityType(
@@ -88,7 +88,6 @@ fun EditArtFiltersScreen(
         }
     }
 }
-
 
 private enum class EditArtFiltersSectionType(
     override val headerStrRes: Int,

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/filters/sections/SectionDate.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/filters/sections/SectionDate.kt
@@ -1,12 +1,16 @@
 package com.activityartapp.presentation.editArtScreen.subscreens.filters.sections
 
 import android.app.DatePickerDialog
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.activityartapp.R
 import com.activityartapp.architecture.EventReceiver
 import com.activityartapp.presentation.common.button.Button
@@ -19,20 +23,89 @@ import com.activityartapp.presentation.editArtScreen.composables.RadioButtonCont
 import com.activityartapp.presentation.editArtScreen.subscreens.filters.composables.FilterCount
 import com.activityartapp.presentation.ui.theme.spacing
 import com.activityartapp.util.classes.YearMonthDay
+import kotlin.random.Random
 
 @Composable
 fun SectionDate(
-    count: Int,
-    dateSelections: List<DateSelection>,
-    dateSelectionSelectedIndex: Int,
+    count: State<Int>,
+    dateSelections: SnapshotStateList<DateSelection>,
+    dateSelectionSelectedIndex: State<Int>,
     eventReceiver: EventReceiver<EditArtViewEvent>
 ) {
-    val customDateSelection = dateSelections
-        .firstOrNull { it is DateSelection.Custom } as? DateSelection.Custom
-        ?: error("Missing DateSelection.Custom from dateSelections.")
+    DateSelectionRowHandler(
+        dateSelections,
+        dateSelectionSelectedIndex.value,
+        eventReceiver::onEvent,
+        eventReceiver::onEvent,
+        eventReceiver::onEvent
+    )
+    FilterCount(count.value)
+}
 
-    val rangeSelected = customDateSelection.dateSelected
-    val rangeTotal = customDateSelection.dateTotal
+@Composable
+private fun DateSelectionRowHandler(
+    dateSelections: List<DateSelection>,
+    dateSelectionSelectedIndex: Int,
+    onFilterDateSelectionChanged: (FilterDateSelectionChanged) -> Unit,
+    onFilterAfterChanged: (FilterDateCustomChanged.FilterAfterChanged) -> Unit,
+    onFilterBeforeChanged: (FilterDateCustomChanged.FilterBeforeChanged) -> Unit
+) {
+    dateSelections.forEachIndexed { index, selection ->
+        val isSelected = index == dateSelectionSelectedIndex
+        when (selection) {
+            is DateSelection.All -> DateSelectionRowItemAll(
+                isSelected = isSelected,
+                index = index,
+                onFilterDateSelectionChanged = onFilterDateSelectionChanged
+            )
+            is DateSelection.Custom -> DateSelectionRowItemCustom(
+                isSelected = isSelected,
+                index = index,
+                selection = selection,
+                onFilterDateSelectionChanged = onFilterDateSelectionChanged,
+                onFilterAfterChanged = onFilterAfterChanged,
+                onFilterBeforeChanged = onFilterBeforeChanged
+            )
+            is DateSelection.Year -> DateSelectionRowItemYear(
+                isSelected = isSelected,
+                index = index,
+                selection = selection,
+                onFilterDateSelectionChanged = onFilterDateSelectionChanged
+            )
+        }
+
+    }
+}
+
+@Composable
+private fun DateSelectionRowItemAll(
+    isSelected: Boolean,
+    index: Int,
+    onFilterDateSelectionChanged: (FilterDateSelectionChanged) -> Unit
+) {
+    RadioButtonContentRow(
+        isSelected = isSelected,
+        text = stringResource(R.string.edit_art_filters_date_include_all)
+    ) {
+        onFilterDateSelectionChanged(
+            FilterDateSelectionChanged(
+                index
+            )
+        )
+    }
+}
+
+@Composable
+private fun DateSelectionRowItemCustom(
+    isSelected: Boolean,
+    index: Int,
+    selection: DateSelection.Custom,
+    onFilterDateSelectionChanged: (FilterDateSelectionChanged) -> Unit,
+    onFilterAfterChanged: (FilterDateCustomChanged.FilterAfterChanged) -> Unit,
+    onFilterBeforeChanged: (FilterDateCustomChanged.FilterBeforeChanged) -> Unit
+) {
+    val rangeSelected = selection.dateSelected
+    val rangeTotal = selection.dateTotal
 
     val ymdTotalStart = YearMonthDay.fromUnixMs(rangeTotal.first)
     val ymdTotalEnd = YearMonthDay.fromUnixMs(rangeTotal.last)
@@ -48,7 +121,7 @@ fun SectionDate(
             // Force cancel to reset active date
             setOnDismissListener { datePicker.updateDate(year, month, day) }
             setOnDateSetListener { _, year, month, dayOfMonth ->
-                eventReceiver.onEvent(
+                onFilterAfterChanged(
                     FilterDateCustomChanged.FilterAfterChanged(
                         changedTo = YearMonthDay(
                             year,
@@ -69,7 +142,7 @@ fun SectionDate(
             // Force cancel to reset active date
             setOnDismissListener { datePicker.updateDate(year, month, day) }
             setOnDateSetListener { _, year, month, dayOfMonth ->
-                eventReceiver.onEvent(
+                onFilterBeforeChanged(
                     FilterDateCustomChanged.FilterBeforeChanged(
                         changedTo = YearMonthDay(
                             year,
@@ -83,51 +156,60 @@ fun SectionDate(
             datePicker.minDate = ymdSelectedStart.unixMs
         }
     }
-
-    dateSelections.forEachIndexed { index, selection ->
-        RadioButtonContentRow(
-            isSelected = index == dateSelectionSelectedIndex,
-            text = when (selection) {
-                is DateSelection.All -> stringResource(R.string.edit_art_filters_date_include_all)
-                is DateSelection.Year -> selection.year.toString()
-                is DateSelection.Custom -> stringResource(R.string.edit_art_filters_date_custom_range)
-            },
-            content = {
-                if (selection is DateSelection.Custom) {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(spacing.small),
-                        verticalAlignment = Alignment.CenterVertically
+    RadioButtonContentRow(
+        isSelected = isSelected,
+        text = stringResource(R.string.edit_art_filters_date_custom_range),
+        content = {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(spacing.small),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                selection.apply {
+                    Button(
+                        emphasis = ButtonEmphasis.MEDIUM,
+                        modifier = Modifier.weight(1f, true),
+                        labelText = stringResource(R.string.edit_art_filters_date_start),
+                        size = ButtonSize.LARGE,
+                        text = ymdSelectedStart.toString()
                     ) {
-                        selection.apply {
-                            Button(
-                                emphasis = ButtonEmphasis.MEDIUM,
-                                modifier = Modifier.weight(1f, true),
-                                labelText = stringResource(R.string.edit_art_filters_date_start),
-                                size = ButtonSize.LARGE,
-                                text = ymdSelectedStart.toString()
-                            ) {
-                                startDialog.show()
-                            }
-                            Button(
-                                emphasis = ButtonEmphasis.MEDIUM,
-                                modifier = Modifier.weight(1f, true),
-                                labelText = stringResource(R.string.edit_art_filters_date_end),
-                                size = ButtonSize.LARGE,
-                                text = ymdSelectedEnd.toString()
-                            ) {
-                                endDialog.show()
-                            }
-                        }
+                        startDialog.show()
+                    }
+                    Button(
+                        emphasis = ButtonEmphasis.MEDIUM,
+                        modifier = Modifier.weight(1f, true),
+                        labelText = stringResource(R.string.edit_art_filters_date_end),
+                        size = ButtonSize.LARGE,
+                        text = ymdSelectedEnd.toString()
+                    ) {
+                        endDialog.show()
                     }
                 }
             }
-        ) {
-            eventReceiver.onEvent(
-                FilterDateSelectionChanged(
-                    index
-                )
-            )
         }
+    ) {
+        onFilterDateSelectionChanged(
+            FilterDateSelectionChanged(
+                index
+            )
+        )
     }
-    FilterCount(count)
+}
+
+@Composable
+private fun DateSelectionRowItemYear(
+    isSelected: Boolean,
+    index: Int,
+    selection: DateSelection.Year,
+    onFilterDateSelectionChanged: (FilterDateSelectionChanged) -> Unit
+) {
+    RadioButtonContentRow(
+        isSelected = isSelected,
+        text = selection.year.toString()
+    ) {
+        onFilterDateSelectionChanged(
+            FilterDateSelectionChanged(
+                index
+            )
+        )
+    }
 }


### PR DESCRIPTION
* This commit improves the performance of the FILTERS date ViewEvents
* Recomposition is limited, whereas previously all elements were recomposed on something as simple as changing the year