### PR TITLE
Improve performance of Filter Types by limiting recomposition & bug fix

### DIFF
--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
@@ -180,7 +180,7 @@ sealed interface EditArtViewState : ViewState {
         val filterDistanceTotalEnd: State<Double?>,
         val filterDistancePendingChangeStart: State<String?>,
         val filterDistancePendingChangeEnd: State<String?>,
-        val filterTypes: SnapshotStateMap<SportType, Boolean>,
+        val filterTypes: SnapshotStateList<Pair<SportType, Boolean>>,
         override val pagerStateWrapper: PagerStateWrapper,
         val listStateFilter: LazyListState = LazyListState(),
         val listStateStyle: LazyListState = LazyListState(),

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/filters/EditArtFiltersScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/filters/EditArtFiltersScreen.kt
@@ -34,7 +34,7 @@ fun EditArtFiltersScreen(
     distancePendingChangeStart: State<String?>,
     distancePendingChangeEnd: State<String?>,
     listState: LazyListState,
-    typesWithSelectedFlag: SnapshotStateMap<SportType, Boolean>,
+    typesWithSelectedFlag: SnapshotStateList<Pair<SportType, Boolean>>,
     eventReceiver: EventReceiver<EditArtViewEvent>
 ) {
     val sections = mutableListOf<EditArtFiltersSectionType>().apply {
@@ -44,7 +44,7 @@ fun EditArtFiltersScreen(
         if (typesWithSelectedFlag.isNotEmpty()) {
             add(EditArtFiltersSectionType.ACTIVITY_TYPE)
         }
-        if (distanceTotalStart.value != null) { // todo add back start != end case reminder
+        if (distanceTotalStart.value != null && distanceTotalStart.value != distanceTotalEnd.value) { // todo add back start != end case reminder
             add(EditArtFiltersSectionType.DISTANCE)
         }
     }
@@ -66,7 +66,7 @@ fun EditArtFiltersScreen(
                     )
                     EditArtFiltersSectionType.ACTIVITY_TYPE -> SectionActivityType(
                         count = activitiesCountType.value,
-                        typesWithSelectedFlag = typesWithSelectedFlag.toList(),
+                        typesWithSelectedFlag = typesWithSelectedFlag,
                         eventReceiver = eventReceiver
                     )
                     EditArtFiltersSectionType.DISTANCE -> distanceTotalEnd.value?.let {

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/filters/sections/SectionActivityType.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/filters/sections/SectionActivityType.kt
@@ -6,10 +6,12 @@ import androidx.compose.material.Checkbox
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.stringResource
 import com.activityartapp.architecture.EventReceiver
 import com.activityartapp.presentation.editArtScreen.EditArtViewEvent
+import com.activityartapp.presentation.editArtScreen.EditArtViewEvent.ArtMutatingEvent.FilterChanged
 import com.activityartapp.presentation.editArtScreen.subscreens.filters.composables.FilterCount
 import com.activityartapp.presentation.ui.theme.spacing
 import com.activityartapp.util.enums.SportType
@@ -17,28 +19,50 @@ import com.activityartapp.util.enums.SportType
 @Composable
 fun SectionActivityType(
     count: Int,
-    typesWithSelectedFlag: List<Pair<SportType, Boolean>>,
+    typesWithSelectedFlag: SnapshotStateList<Pair<SportType, Boolean>>,
     eventReceiver: EventReceiver<EditArtViewEvent>
 ) {
-    typesWithSelectedFlag.forEach { typeMap ->
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(spacing.medium),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Checkbox(
-                checked = typeMap.second,
-                onCheckedChange = {
-                    eventReceiver.onEvent(
-                        EditArtViewEvent.ArtMutatingEvent.FilterChanged.FilterTypeToggled(
-                            typeMap.first
-                        )
-                    )
-                })
-            Text(
-                text = stringResource(typeMap.first.stringRes),
-                style = MaterialTheme.typography.body1
-            )
-        }
-    }
+    TypeRows(
+        typesWithSelectedFlag = typesWithSelectedFlag,
+        onFilterTypeToggled = eventReceiver::onEvent
+    )
     FilterCount(count)
+}
+
+@Composable
+private fun TypeRows(
+    typesWithSelectedFlag: List<Pair<SportType, Boolean>>,
+    onFilterTypeToggled: (FilterChanged.FilterTypeToggled) -> Unit
+) {
+    typesWithSelectedFlag.forEach { selection ->
+        TypeRowItem(
+            typeWithSelectedFlag = selection,
+            onFilterTypeToggled = onFilterTypeToggled
+        )
+    }
+}
+
+@Composable
+private fun TypeRowItem(
+    typeWithSelectedFlag: Pair<SportType, Boolean>,
+    onFilterTypeToggled: (FilterChanged.FilterTypeToggled) -> Unit
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(spacing.medium),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Checkbox(
+            checked = typeWithSelectedFlag.second,
+            onCheckedChange = {
+                onFilterTypeToggled(
+                    FilterChanged.FilterTypeToggled(
+                        type = typeWithSelectedFlag.first
+                    )
+                )
+            })
+        Text(
+            text = stringResource(typeWithSelectedFlag.first.stringRes),
+            style = MaterialTheme.typography.body1
+        )
+    }
 }

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionColorBackgroundGradient.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/style/sections/SectionColorBackgroundGradient.kt
@@ -56,7 +56,7 @@ fun SectionColorBackgroundGradient(
                 }
             )
             .background(MaterialTheme.colors.background)
-            .padding(vertical = spacing.xSmall),
+            .padding(vertical = spacing.small),
         horizontalArrangement = Arrangement.spacedBy(spacing.xSmall)
     ) {
         item { Spacer(modifier = Modifier.width(spacing.xSmall)) }

--- a/app/src/main/java/com/activityartapp/util/enums/SportType.kt
+++ b/app/src/main/java/com/activityartapp/util/enums/SportType.kt
@@ -2,11 +2,13 @@ package com.activityartapp.util.enums
 
 import androidx.annotation.StringRes
 import com.activityartapp.R
+import javax.annotation.concurrent.Immutable
 
 /**
  * Last updated 2/15/2023
  * https://developers.strava.com/docs/reference/#api-models-SportType
   */
+@Immutable
 enum class SportType(@StringRes val stringRes: Int) {
     ALPINE_SKI(R.string.sport_type_alpine_ski),
     BACKCOUNTRY_SKI(R.string.sport_type_backcountry_ski),


### PR DESCRIPTION
* This commit improves the performance of the FILTERS SportTypes section by limiting recomposition.
* Various bugs are fixed relating to issues with threading by making all filter-mutating & accessing operations on the activity thread.