### PR TITLE
Zoom-in and pan when previewing Edit Art

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,6 +76,7 @@ dependencies {
     // Android Studio Preview support
     implementation 'androidx.compose.ui:ui-tooling-preview'
     debugImplementation 'androidx.compose.ui:ui-tooling'
+    implementation 'androidx.compose.ui:ui-util'
 
     // UI Tests
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'

--- a/app/src/main/java/com/activityartapp/presentation/common/ScreenMeasurer.kt
+++ b/app/src/main/java/com/activityartapp/presentation/common/ScreenMeasurer.kt
@@ -4,6 +4,7 @@ import android.util.Size
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
@@ -11,16 +12,12 @@ import androidx.compose.ui.platform.LocalDensity
 @Composable
 fun ScreenMeasurer(onMeasured: (Size) -> Unit) {
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        println("in box with constraints scope...")
         val localDensity = LocalDensity.current
-        // Not sure derived state is necessary here: perhaps remove later
-        val maxSize = derivedStateOf {
-            localDensity.run {
-                Size(
-                    maxWidth.toPx().toInt(),
-                    maxHeight.toPx().toInt()
-                )
-            }
+        SideEffect {
+            onMeasured(localDensity.run {
+                Size(maxWidth.toPx().toInt(), maxHeight.toPx().toInt())
+            })
         }
-        onMeasured(maxSize.value)
     }
 }

--- a/app/src/main/java/com/activityartapp/presentation/common/ScreenMeasurer.kt
+++ b/app/src/main/java/com/activityartapp/presentation/common/ScreenMeasurer.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.platform.LocalDensity
 fun ScreenMeasurer(onMeasured: (Size) -> Unit) {
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
         val localDensity = LocalDensity.current
+        // Not sure derived state is necessary here: perhaps remove later
         val maxSize = derivedStateOf {
             localDensity.run {
                 Size(

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
@@ -59,8 +59,8 @@ sealed interface EditArtViewEvent : ViewEvent {
         val zoom: Float
     ) : EditArtViewEvent
 
+    data class PreviewSpaceMeasured(val size: Size) : ArtMutatingEvent
     object SaveClicked : EditArtViewEvent
-    data class ScreenMeasured(val size: Size) : EditArtViewEvent
     sealed interface SizeCustomPendingChanged : EditArtViewEvent {
         val changedTo: String
 
@@ -193,7 +193,7 @@ sealed interface EditArtViewState : ViewState {
         override val pagerStateWrapper: PagerStateWrapper,
         val listStateFilter: LazyListState = LazyListState(),
         val listStateStyle: LazyListState = LazyListState(),
-        val previewOffset: State<Float>,
+        val previewOffset: State<Offset>,
         val previewScale: State<Float>,
         val scrollStateType: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
         val scrollStateResize: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
@@ -229,8 +229,6 @@ sealed interface EditArtViewState : ViewState {
 
         @Inject
         lateinit var resolutionListFactory: ResolutionListFactory
-
-
     }
 }
 

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
@@ -59,6 +59,18 @@ sealed interface EditArtViewEvent : ViewEvent {
         val zoom: Float
     ) : EditArtViewEvent
 
+    data class PreviewGestureZoom(
+        val centroid: Offset,
+        val pan: Offset,
+        val zoom: Float
+    ) : EditArtViewEvent
+
+    data class PreviewGestureDrag(
+        val pan: Offset,
+        val pressed: Boolean
+    ) : EditArtViewEvent
+
+
     data class PreviewSpaceMeasured(val size: Size) : ArtMutatingEvent
     object SaveClicked : EditArtViewEvent
     sealed interface SizeCustomPendingChanged : EditArtViewEvent {

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
@@ -193,6 +193,8 @@ sealed interface EditArtViewState : ViewState {
         override val pagerStateWrapper: PagerStateWrapper,
         val listStateFilter: LazyListState = LazyListState(),
         val listStateStyle: LazyListState = LazyListState(),
+        val previewOffset: State<Float>,
+        val previewScale: State<Float>,
         val scrollStateType: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
         val scrollStateResize: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
         val scrollStateSort: ScrollState = ScrollState(INITIAL_SCROLL_STATE),

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
@@ -53,10 +53,9 @@ sealed interface EditArtViewEvent : ViewEvent {
 
     object NavigateUpClicked : EditArtViewEvent
     data class PageHeaderClicked(val position: Int) : EditArtViewEvent
-    data class PreviewGesture(
-        val centroid: Offset,
+    data class PreviewGestureDrag(
         val pan: Offset,
-        val zoom: Float
+        val pressed: Boolean
     ) : EditArtViewEvent
 
     data class PreviewGestureZoom(
@@ -64,12 +63,6 @@ sealed interface EditArtViewEvent : ViewEvent {
         val pan: Offset,
         val zoom: Float
     ) : EditArtViewEvent
-
-    data class PreviewGestureDrag(
-        val pan: Offset,
-        val pressed: Boolean
-    ) : EditArtViewEvent
-
 
     data class PreviewSpaceMeasured(val size: Size) : ArtMutatingEvent
     object SaveClicked : EditArtViewEvent

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.snapshots.SnapshotMutableState
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.res.stringResource
 import com.activityartapp.R
@@ -52,6 +53,12 @@ sealed interface EditArtViewEvent : ViewEvent {
 
     object NavigateUpClicked : EditArtViewEvent
     data class PageHeaderClicked(val position: Int) : EditArtViewEvent
+    data class PreviewGesture(
+        val centroid: Offset,
+        val pan: Offset,
+        val zoom: Float
+    ) : EditArtViewEvent
+
     object SaveClicked : EditArtViewEvent
     data class ScreenMeasured(val size: Size) : EditArtViewEvent
     sealed interface SizeCustomPendingChanged : EditArtViewEvent {

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
@@ -95,9 +95,6 @@ fun CollectViewState(
             }
         ) {
             if (this@apply is EditArtViewState.Standby) {
-                ScreenMeasurer {
-                    eventReceiver.onEvent(PreviewSpaceMeasured(size = it))
-                }
 
                 val activeHeader = EditArtHeaderType
                     .fromOrdinal(pagerStateWrapper.pagerState.currentPage)
@@ -187,7 +184,11 @@ fun CollectViewState(
                         }
                     }
                 }
+                ScreenMeasurer {
+                    eventReceiver.onEvent(PreviewSpaceMeasured(size = it))
+                }
             }
+
         }
 
         DialogHandler(

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
@@ -41,9 +41,6 @@ import com.google.accompanist.pager.ExperimentalPagerApi
 
 @Composable
 fun EditArtViewDelegate(viewModel: EditArtViewModel) {
-    ScreenMeasurer {
-        viewModel.onEvent(ScreenMeasured(size = it))
-    }
     CollectViewState(
         flow = viewModel,
         eventReceiver = viewModel
@@ -98,6 +95,10 @@ fun CollectViewState(
             }
         ) {
             if (this@apply is EditArtViewState.Standby) {
+                ScreenMeasurer {
+                    eventReceiver.onEvent(PreviewSpaceMeasured(size = it))
+                }
+
                 val activeHeader = EditArtHeaderType
                     .fromOrdinal(pagerStateWrapper.pagerState.currentPage)
 
@@ -124,6 +125,8 @@ fun CollectViewState(
                                 atLeastOneActivitySelected,
                                 backgroundIsTransparent,
                                 bitmap,
+                                previewOffset,
+                                previewScale,
                                 eventReceiver
                             )
                             FILTERS -> YearMonthDay.run {

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
@@ -621,7 +621,7 @@ class EditArtViewModel @Inject constructor(
         //   val scaledExcessX = (largestWidth) - smallestWidth
         val scaledExcessX = (scaledBitmapWidth) - smallestWidth
         val maximumOffsetX: Float = scaledExcessX / newScale
-   //     val scaledExcessY = (largestHeight) - smallestHeight
+        //     val scaledExcessY = (largestHeight) - smallestHeight
         val scaledExcessY = (scaledBitmapHeight) - smallestHeight
 
         val maximumOffsetY: Float = scaledExcessY / newScale
@@ -653,7 +653,7 @@ class EditArtViewModel @Inject constructor(
         val newOffset =
             (_previewOffset.value + oldCentroid - (newCentroid + event.pan / oldScale)).run {
                 copy(
-                   x = x.coerceIn(0f..maximumOffsetX) - decayedExcessX,
+                    x = x.coerceIn(0f..maximumOffsetX) - decayedExcessX,
                     y = y.coerceIn(0f..maximumOffsetY) - decayedExcessY
                 )
             }
@@ -748,7 +748,20 @@ class EditArtViewModel @Inject constructor(
     }
 
     private fun onScreenMeasured(event: PreviewSpaceMeasured) {
-        previewScreenSize = event.size
+        println("here, screen measured")
+        previewScreenSize = event.size.apply {
+            _previewOffset.value = imageSizeUtils.offsetToCenterImageInContainer(
+                container = this,
+                image = imageSizeUtils.sizeToMaximumSize(
+                    actualSize = _sizeResolutionList[_sizeResolutionListSelectedIndex.value].run {
+                        Size(widthPx, heightPx)
+                    },
+                    maximumSize = this
+                )
+            )
+            println("changing offset to ${_previewOffset.value}")
+            _previewScale.value = 1f
+        }
     }
 
     private fun onSizeChanged(event: SizeChanged) {
@@ -1048,25 +1061,25 @@ class EditArtViewModel @Inject constructor(
 
     private val filteredTypes: List<SportType>
         get() = _filterTypes.filter { it.second }.map { it.first }
-    /*
+/*
 
-    .takemutableListOf<SportType>().apply {
-    /** [_filterTypes] must NOT be iterated over using an [Iterator] or a
-     * [ConcurrentModificationException] will occur when rapidly toggling a filter type.
-     *
-     * Though it might seem this may cause an issue where the result of [filteredTypes]
-     * does not reflect the UI, it does not seem to by manual test.
-     *
-     * If it does cause issue, an alternative solution is to move access of this
-     * variable into the [activitiesProcessingDispatcher] thread - or just remove that thread. **/
-    for (i in 0.._filterTypes.lastIndex) {
-        _filterTypes
-            .getOrNull(i)
-            ?.takeIf { it.second }
-            ?.let { add(it.first) }
-    }
+.takemutableListOf<SportType>().apply {
+/** [_filterTypes] must NOT be iterated over using an [Iterator] or a
+ * [ConcurrentModificationException] will occur when rapidly toggling a filter type.
+ *
+ * Though it might seem this may cause an issue where the result of [filteredTypes]
+ * does not reflect the UI, it does not seem to by manual test.
+ *
+ * If it does cause issue, an alternative solution is to move access of this
+ * variable into the [activitiesProcessingDispatcher] thread - or just remove that thread. **/
+for (i in 0.._filterTypes.lastIndex) {
+    _filterTypes
+        .getOrNull(i)
+        ?.takeIf { it.second }
+        ?.let { add(it.first) }
+}
 
-     */
+ */
 
 
     private val filteredDistanceRangeMeters: IntRange

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
@@ -239,6 +239,8 @@ class EditArtViewModel @Inject constructor(
 
     // PREVIEW
     private val _bitmap = mutableStateOf<Bitmap?>(null) // not save
+    private val _previewOffset = mutableStateOf(0f)
+    private val _previewScale = mutableStateOf(1f)
 
     // FILTERS
     private val _filterActivitiesCountDate = mutableStateOf(0)
@@ -325,6 +327,8 @@ class EditArtViewModel @Inject constructor(
                 filterDistancePendingChangeStart = _filterDistancePendingChangeStart,
                 filterDistancePendingChangeEnd = _filterDistancePendingChangeEnd,
                 filterTypes = _filterTypes,
+                previewOffset = _previewOffset,
+                previewScale = _previewScale,
                 sizeResolutionList = _sizeResolutionList,
                 sizeResolutionListSelectedIndex = _sizeResolutionListSelectedIndex,
                 sortDirectionTypeSelected = _sortDirectionTypeSelected,
@@ -384,6 +388,7 @@ class EditArtViewModel @Inject constructor(
             is DialogNavigateUpConfirmed -> onDialogNavigateUpConfirmed()
             is FilterDistancePendingChange -> onFilterDistancePendingChange(event)
             is NavigateUpClicked -> onNavigateUpClicked()
+            is PreviewGesture -> onPreviewGesture(event)
             is SaveClicked -> onSaveClicked()
             is ScreenMeasured -> onScreenMeasured(event)
             is SizeCustomPendingChanged -> onSizeCustomPendingChanged(event)
@@ -571,6 +576,10 @@ class EditArtViewModel @Inject constructor(
 
     private fun onNavigateUpClicked() {
         _dialogActive.value = EditArtDialog.NavigateUp
+    }
+
+    private fun onPreviewGesture(event: PreviewGesture) {
+
     }
 
     private fun onPageHeaderClicked(event: PageHeaderClicked) {

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.util.Size
 import androidx.compose.runtime.*
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.activityartapp.architecture.BaseRoutingViewModel
@@ -231,6 +232,7 @@ class EditArtViewModel @Inject constructor(
     private val activitiesProcessingDispatcher by lazy { Dispatchers.Default.limitedParallelism(1) }
     private var imageJob: Job? = null
     private val imageProcessingDispatcher by lazy { Dispatchers.Default.limitedParallelism(1) }
+    private val velocityTracker = VelocityTracker()
 
     // The size of the screen excluding the top bar
     private var previewScreenSize: Size? = null
@@ -611,6 +613,7 @@ class EditArtViewModel @Inject constructor(
             } + offsetToCenter
 
             _previewOffset.value = newOffset
+            velocityTracker.addPosition(System.currentTimeMillis(), newOffset)
         }
     }
 

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/CustomDetection.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/CustomDetection.kt
@@ -1,0 +1,63 @@
+package com.activityartapp.presentation.editArtScreen.subscreens.preview
+
+import androidx.compose.foundation.gestures.*
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.positionChanged
+import kotlin.math.PI
+import kotlin.math.abs
+import androidx.compose.ui.util.fastAny
+import androidx.compose.ui.util.fastForEach
+
+suspend fun PointerInputScope.detectZoomPanGesture(
+    onZoom: (centroid: Offset, pan: Offset, zoom: Float) -> Unit,
+    onPan: (pan: Offset) -> Unit
+) {
+    forEachGesture {
+        awaitPointerEventScope {
+            var zoom = 1f
+            var pan = Offset.Zero
+            var pastTouchSlop = false
+            val touchSlop = viewConfiguration.touchSlop
+
+            awaitFirstDown(requireUnconsumed = false)
+            do {
+                val event = awaitPointerEvent()
+                val canceled = event.changes.fastAny { it.isConsumed }
+                if (!canceled) {
+                    val zoomChange = event.calculateZoom()
+                    val panChange = event.calculatePan()
+
+                    if (!pastTouchSlop) {
+                        zoom *= zoomChange
+                        pan += panChange
+
+                        val centroidSize = event.calculateCentroidSize(useCurrent = false)
+                        val zoomMotion = abs(1 - zoom) * centroidSize
+                        val panMotion = pan.getDistance()
+
+                        if (zoomMotion > touchSlop ||
+                            panMotion > touchSlop
+                        ) {
+                            pastTouchSlop = true
+                        }
+                    }
+
+                    if (pastTouchSlop) {
+                        val centroid = event.calculateCentroid(useCurrent = false)
+                        if (zoomChange != 1f) {
+                            onZoom(centroid, panChange, zoomChange)
+                        } else if (panChange != Offset.Zero) {
+                            onPan(panChange)
+                        }
+                        event.changes.fastForEach {
+                            if (it.positionChanged()) {
+                                it.consume()
+                            }
+                        }
+                    }
+                }
+            } while (!canceled && event.changes.fastAny { it.pressed })
+        }
+    }
+}

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
@@ -2,8 +2,9 @@ package com.activityartapp.presentation.editArtScreen.subscreens.preview
 
 import android.graphics.Bitmap
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.CircularProgressIndicator
@@ -12,7 +13,6 @@ import androidx.compose.runtime.State
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
@@ -23,7 +23,6 @@ import com.activityartapp.R
 import com.activityartapp.architecture.EventReceiver
 import com.activityartapp.presentation.common.ErrorComposable
 import com.activityartapp.presentation.common.ScreenBackground
-import com.activityartapp.presentation.common.ScreenMeasurer
 import com.activityartapp.presentation.editArtScreen.EditArtViewEvent
 
 @Composable
@@ -49,29 +48,22 @@ fun EditArtPreview(
                 modifier = Modifier
                     .fillMaxSize()
                     .pointerInput(Unit) {
-                        detectTransformGestures(
-                            onGesture = { centroid, pan, gestureZoom, _ ->
-                                eventReceiver.onEvent(
-                                    EditArtViewEvent.PreviewGesture(
-                                        centroid,
-                                        pan,
-                                        gestureZoom
-                                    )
-                                )
-                            }
+                        detectZoomPanGesture(
+                            { _, _, _ -> println("here, zoom") },
+                            { _ -> println("here, drag") }
                         )
                     }
             ) {
                 Box(
                     modifier = Modifier
-                    .fillMaxSize()
-                    .graphicsLayer {
-                        translationX = -offset.value.x * scale.value
-                        translationY = -offset.value.y * scale.value
-                        scaleX = scale.value
-                        scaleY = scale.value
-                        transformOrigin = TransformOrigin(0f, 0f)
-                    }
+                        .fillMaxSize()
+                        .graphicsLayer {
+                            translationX = -offset.value.x
+                            translationY = -offset.value.y
+                            scaleX = scale.value
+                            scaleY = scale.value
+                            transformOrigin = TransformOrigin(0f, 0f)
+                        }
                 ) {
                     Image(
                         bitmap = it.asImageBitmap(),

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
@@ -56,7 +56,12 @@ fun EditArtPreview(
                                     zoom
                                 ))
                             },
-                            { _, released -> println("here, drag released $released") }
+                            { pan, released ->
+                                eventReceiver.onEvent(EditArtViewEvent.PreviewGestureDrag(
+                                   pan,
+                                   !released
+                                ))
+                            }
                         )
                     }
             ) {

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
@@ -8,7 +8,10 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
@@ -23,6 +26,8 @@ fun EditArtPreview(
     atLeastOneActivitySelected: State<Boolean>,
     backgroundIsTransparent: State<Boolean>,
     bitmap: State<Bitmap?>,
+    offset: State<Offset>,
+    scale: State<Float>,
     eventReceiver: EventReceiver<EditArtViewEvent>
 ) {
     if (!atLeastOneActivitySelected.value) {
@@ -54,10 +59,10 @@ fun EditArtPreview(
                         )
                     }
                     .graphicsLayer {
-                        translationX = -offset.x * zoom
-                        translationY = -offset.y * zoom
-                        scaleX = zoom
-                        scaleY = zoom
+                        translationX = -offset.value.x * scale.value
+                        translationY = -offset.value.y * scale.value
+                        scaleX = scale.value
+                        scaleY = scale.value
                         transformOrigin = TransformOrigin(0f, 0f)
                     },
                 contentScale = ContentScale.Fit,

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
@@ -2,12 +2,14 @@ package com.activityartapp.presentation.editArtScreen.subscreens.preview
 
 import android.graphics.Bitmap
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import com.activityartapp.R
@@ -36,7 +38,28 @@ fun EditArtPreview(
             Image(
                 bitmap = it.asImageBitmap(),
                 contentDescription = stringResource(R.string.edit_art_preview_image_content_description),
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .pointerInput(Unit) {
+                        detectTransformGestures(
+                            onGesture = { centroid, pan, gestureZoom, _ ->
+                                eventReceiver.onEvent(
+                                    EditArtViewEvent.PreviewGesture(
+                                        centroid,
+                                        pan,
+                                        gestureZoom
+                                    )
+                                )
+                            }
+                        )
+                    }
+                    .graphicsLayer {
+                        translationX = -offset.x * zoom
+                        translationY = -offset.y * zoom
+                        scaleX = zoom
+                        scaleY = zoom
+                        transformOrigin = TransformOrigin(0f, 0f)
+                    },
                 contentScale = ContentScale.Fit,
             )
             /*

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
@@ -2,13 +2,17 @@ package com.activityartapp.presentation.editArtScreen.subscreens.preview
 
 import android.graphics.Bitmap
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
@@ -19,6 +23,7 @@ import com.activityartapp.R
 import com.activityartapp.architecture.EventReceiver
 import com.activityartapp.presentation.common.ErrorComposable
 import com.activityartapp.presentation.common.ScreenBackground
+import com.activityartapp.presentation.common.ScreenMeasurer
 import com.activityartapp.presentation.editArtScreen.EditArtViewEvent
 
 @Composable
@@ -40,9 +45,7 @@ fun EditArtPreview(
         }
     } else {
         bitmap.value?.let {
-            Image(
-                bitmap = it.asImageBitmap(),
-                contentDescription = stringResource(R.string.edit_art_preview_image_content_description),
+            Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .pointerInput(Unit) {
@@ -58,15 +61,26 @@ fun EditArtPreview(
                             }
                         )
                     }
+            ) {
+                Box(
+                    modifier = Modifier
+                    .fillMaxSize()
                     .graphicsLayer {
                         translationX = -offset.value.x * scale.value
                         translationY = -offset.value.y * scale.value
                         scaleX = scale.value
                         scaleY = scale.value
                         transformOrigin = TransformOrigin(0f, 0f)
-                    },
-                contentScale = ContentScale.Fit,
-            )
+                    }
+                ) {
+                    Image(
+                        bitmap = it.asImageBitmap(),
+                        contentDescription = stringResource(R.string.edit_art_preview_image_content_description),
+                        modifier = Modifier,
+                        contentScale = ContentScale.Fit,
+                    )
+                }
+            }
             /*
             if (backgroundIsTransparent.value) {
                 Button(
@@ -78,7 +92,10 @@ fun EditArtPreview(
 
              */
         } ?: run {
-            CircularProgressIndicator()
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) { CircularProgressIndicator() }
         }
     }
 }

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
@@ -49,8 +49,14 @@ fun EditArtPreview(
                     .fillMaxSize()
                     .pointerInput(Unit) {
                         detectZoomPanGesture(
-                            { _, _, _ -> println("here, zoom") },
-                            { _ -> println("here, drag") }
+                            { centroid, pan, zoom ->
+                                eventReceiver.onEvent(EditArtViewEvent.PreviewGestureZoom(
+                                    centroid,
+                                    pan,
+                                    zoom
+                                ))
+                            },
+                            { _, released -> println("here, drag released $released") }
                         )
                     }
             ) {

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/sort/EditArtSortScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/sort/EditArtSortScreen.kt
@@ -18,7 +18,7 @@ import com.activityartapp.util.enums.EditArtSortType
 
 
 @Composable
-fun ColumnScope.EditArtSortScreen(
+fun EditArtSortScreen(
     sortTypeSelected: State<EditArtSortType>,
     sortDirectionSelected: State<EditArtSortDirectionType>,
     eventReceiver: EventReceiver<EditArtViewEvent>

--- a/app/src/main/java/com/activityartapp/util/ImageSizeUtils.kt
+++ b/app/src/main/java/com/activityartapp/util/ImageSizeUtils.kt
@@ -1,6 +1,7 @@
 package com.activityartapp.util
 
 import android.util.Size
+import androidx.compose.ui.geometry.Offset
 
 class ImageSizeUtils {
 
@@ -37,5 +38,21 @@ class ImageSizeUtils {
             val widthWhenHeightScaled = maximumSize.height * widthHeightAspectRatio
             Size(widthWhenHeightScaled.toInt(), maximumSize.height)
         }
+    }
+
+    /**
+     * Given an image within a container, returns the [Offset] necessary to center
+     * the image within its container.
+     *
+     * Assumes the image offset with [Offset.Zero] is left-aligned.
+     */
+    fun offsetToCenterImageInContainer(
+        container: Size,
+        image: Size
+    ): Offset {
+        return Offset(
+            (image.width.toFloat() - container.width) / 2F,
+            (image.height.toFloat() - container.height) / 2F
+        )
     }
 }

--- a/app/src/main/java/com/activityartapp/util/VisualizationUtils.kt
+++ b/app/src/main/java/com/activityartapp/util/VisualizationUtils.kt
@@ -31,6 +31,27 @@ class VisualizationUtils @Inject constructor(
         private const val TRANSPARENT_GRID_SIZE_PX = 50
     }
 
+    fun createArtOnCanvas(
+        backgroundAngleType: AngleType,
+        backgroundType: BackgroundType,
+        backgroundColorsArgb: List<Int>,
+        canvas: Canvas,
+        colorActivitiesArgb: Int,
+        colorFontArgb: Int,
+        fontAssetPath: String,
+        fontSize: FontSizeType,
+        isPreview: Boolean,
+        sortType: EditArtSortType,
+        sortDirectionType: EditArtSortDirectionType,
+        strokeWidth: StrokeWidthType,
+        @Px paddingFraction: Float = 0.1f,
+        textLeft: String? = null,
+        textCenter: String? = null,
+        textRight: String? = null
+    ) {
+
+    }
+    
     fun createBitmap(
         activities: List<Activity>,
         backgroundAngleType: AngleType,


### PR DESCRIPTION
* This commit adds a zoom-in and pan functionality to Edit Art, and sets up future functionality to enable a fling gesture when panning.