### PR TITLE
Add a fling to the zoom-in, and fix a bug when screen is rotated

### DIFF
--- a/app/src/main/java/com/activityartapp/presentation/common/ScreenMeasurer.kt
+++ b/app/src/main/java/com/activityartapp/presentation/common/ScreenMeasurer.kt
@@ -4,6 +4,7 @@ import android.util.Size
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.Modifier
@@ -12,7 +13,6 @@ import androidx.compose.ui.platform.LocalDensity
 @Composable
 fun ScreenMeasurer(onMeasured: (Size) -> Unit) {
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
-        println("in box with constraints scope...")
         val localDensity = LocalDensity.current
         SideEffect {
             onMeasured(localDensity.run {

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Velocity
 import com.activityartapp.R
 import com.activityartapp.architecture.ViewEvent
 import com.activityartapp.architecture.ViewState
@@ -198,8 +199,6 @@ sealed interface EditArtViewState : ViewState {
         override val pagerStateWrapper: PagerStateWrapper,
         val listStateFilter: LazyListState = LazyListState(),
         val listStateStyle: LazyListState = LazyListState(),
-        val previewOffset: State<Offset>,
-        val previewScale: State<Float>,
         val scrollStateType: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
         val scrollStateResize: ScrollState = ScrollState(INITIAL_SCROLL_STATE),
         val scrollStateSort: ScrollState = ScrollState(INITIAL_SCROLL_STATE),

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtModels.kt
@@ -54,17 +54,6 @@ sealed interface EditArtViewEvent : ViewEvent {
 
     object NavigateUpClicked : EditArtViewEvent
     data class PageHeaderClicked(val position: Int) : EditArtViewEvent
-    data class PreviewGestureDrag(
-        val pan: Offset,
-        val pressed: Boolean
-    ) : EditArtViewEvent
-
-    data class PreviewGestureZoom(
-        val centroid: Offset,
-        val pan: Offset,
-        val zoom: Float
-    ) : EditArtViewEvent
-
     data class PreviewSpaceMeasured(val size: Size) : ArtMutatingEvent
     object SaveClicked : EditArtViewEvent
     sealed interface SizeCustomPendingChanged : EditArtViewEvent {

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
@@ -1,5 +1,6 @@
 package com.activityartapp.presentation.editArtScreen
 
+import android.util.Size
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.FastOutSlowInEasing
@@ -120,9 +121,10 @@ fun CollectViewState(
                         when (it) {
                             PREVIEW -> EditArtPreview(
                                 atLeastOneActivitySelected,
-                                backgroundIsTransparent,
                                 bitmap,
-                                eventReceiver
+                                sizeResolutionList[sizeResolutionListSelectedIndex.value].run {
+                                    Size(widthPx, heightPx)
+                                }
                             )
                             FILTERS -> YearMonthDay.run {
                                 EditArtFiltersScreen(

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewDelegate.kt
@@ -122,8 +122,6 @@ fun CollectViewState(
                                 atLeastOneActivitySelected,
                                 backgroundIsTransparent,
                                 bitmap,
-                                previewOffset,
-                                previewScale,
                                 eventReceiver
                             )
                             FILTERS -> YearMonthDay.run {

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
@@ -233,7 +233,6 @@ class EditArtViewModel @Inject constructor(
     private val activitiesProcessingDispatcher by lazy { Dispatchers.Default.limitedParallelism(1) }
     private var imageJob: Job? = null
     private val imageProcessingDispatcher by lazy { Dispatchers.Default.limitedParallelism(1) }
-    private val velocityTracker = VelocityTracker()
 
     // The size of the screen excluding the top bar
     private var previewScreenSize: Size? = null
@@ -245,9 +244,6 @@ class EditArtViewModel @Inject constructor(
 
     // PREVIEW
     private val _bitmap = mutableStateOf<Bitmap?>(null) // not save
-    private val _previewOffset = mutableStateOf(Offset.Zero)
-    private val _previewScale = mutableStateOf(1f)
-    private val _previewVelocity = mutableStateOf(Velocity(0f, 0f))
 
     // FILTERS
     private val _filterActivitiesCountDate = mutableStateOf(0)
@@ -394,8 +390,6 @@ class EditArtViewModel @Inject constructor(
             is DialogNavigateUpConfirmed -> onDialogNavigateUpConfirmed()
             is FilterDistancePendingChange -> onFilterDistancePendingChange(event)
             is NavigateUpClicked -> onNavigateUpClicked()
-            is PreviewGestureDrag -> onPreviewGestureDrag(event)
-            is PreviewGestureZoom -> onPreviewGestureZoom(event)
             is SaveClicked -> onSaveClicked()
             is SizeCustomPendingChanged -> onSizeCustomPendingChanged(event)
             is StyleColorPendingChanged -> onStyleColorPendingChanged(event)
@@ -585,83 +579,6 @@ class EditArtViewModel @Inject constructor(
         _dialogActive.value = EditArtDialog.NavigateUp
     }
 
-    private fun onPreviewGestureDrag(event: PreviewGestureDrag) {
-        previewScreenSize?.let { screenSize ->
-            val bitmapWidth = _bitmap.value?.width ?: 0
-            val bitmapHeight = _bitmap.value?.height ?: 0
-
-            val scaledBitmapWidth = bitmapWidth * _previewScale.value
-            val scaledBitmapHeight = bitmapHeight * _previewScale.value
-
-            val scaledRequestedOffset = _previewOffset.value - event.pan
-
-            /* Compute the float range which the new offset must be coerced within */
-            val scaledExcessToScreenWidth: Float = scaledBitmapWidth - screenSize.width
-            val scaledExcessToScreenHeight: Float = scaledBitmapHeight - screenSize.height
-            val maxOffsetX: Float = scaledExcessToScreenWidth.coerceAtLeast(minimumValue = 0f)
-            val maxOffsetY: Float = scaledExcessToScreenHeight.coerceAtLeast(minimumValue = 0f)
-            val offsetRangeX = 0f.rangeTo(maxOffsetX)
-            val offsetRangeY = 0f.rangeTo(maxOffsetY)
-            val offsetToCenter = Offset(
-                scaledExcessToScreenWidth.div(2f).coerceAtMost(0f),
-                scaledExcessToScreenHeight.div(2f).coerceAtMost(0f)
-            )
-
-            /* Adjust offset within maximum range */
-            val newOffset = scaledRequestedOffset.run {
-
-                   copy(x = x, y = y.coerceIn(offsetRangeY))
-            } + offsetToCenter
-
-            _previewOffset.value = newOffset
-            velocityTracker.addPosition(System.currentTimeMillis(), newOffset)
-            _previewVelocity.value = velocityTracker.calculateVelocity()
-        }
-    }
-
-    private fun onPreviewGestureZoom(event: PreviewGestureZoom) {
-        previewScreenSize?.let { screenSize ->
-            val oldScale = _previewScale.value
-            val newScale = (oldScale * event.zoom).coerceIn(1f..5f)
-
-            val bitmapWidth = _bitmap.value?.width ?: 0
-            val bitmapHeight = _bitmap.value?.height ?: 0
-
-            val scaledBitmapWidth = bitmapWidth * newScale
-            val scaledBitmapHeight = bitmapHeight * newScale
-
-            /* Compute a new offset which would perfectly center the image within the user's
-            fingers; may be out-of-bounds. */
-            val scaledPrevOffset = _previewOffset.value / oldScale
-            val scaledPrevCent = event.centroid / oldScale
-            val scaledPrevPan = event.pan / oldScale
-            val scaledNewCent = event.centroid / newScale
-            val requestedOffset = scaledPrevOffset + scaledPrevCent - scaledNewCent + scaledPrevPan
-            val scaledRequestedOffset = requestedOffset * newScale
-
-            /* Compute the float range which the new offset must be coerced within */
-            val scaledExcessToScreenWidth: Float = scaledBitmapWidth - screenSize.width
-            val scaledExcessToScreenHeight: Float = scaledBitmapHeight - screenSize.height
-            val maxOffsetX: Float = scaledExcessToScreenWidth.coerceAtLeast(minimumValue = 0f)
-            val maxOffsetY: Float = scaledExcessToScreenHeight.coerceAtLeast(minimumValue = 0f)
-            val offsetRangeX = 0f.rangeTo(maxOffsetX)
-            val offsetRangeY = 0f.rangeTo(maxOffsetY)
-            val offsetToCenter = Offset(
-                scaledExcessToScreenWidth.div(2f).coerceAtMost(0f),
-                scaledExcessToScreenHeight.div(2f).coerceAtMost(0f)
-            )
-
-            /* Adjust offset within maximum range */
-            val newOffset = scaledRequestedOffset.run {
-                copy()
-                copy(x = x, y = y.coerceIn(offsetRangeY))
-            } + offsetToCenter
-
-            _previewOffset.value = newOffset
-            _previewScale.value = newScale
-        }
-    }
-
     private fun onPageHeaderClicked(event: PageHeaderClicked) {
         viewModelScope.launch(Dispatchers.Main.immediate) {
             (lastPushedState as? Standby)?.run {
@@ -748,18 +665,7 @@ class EditArtViewModel @Inject constructor(
     }
 
     private fun onScreenMeasured(event: PreviewSpaceMeasured) {
-        previewScreenSize = event.size.apply {
-            _previewOffset.value = imageSizeUtils.offsetToCenterImageInContainer(
-                container = this,
-                image = imageSizeUtils.sizeToMaximumSize(
-                    actualSize = _sizeResolutionList[_sizeResolutionListSelectedIndex.value].run {
-                        Size(widthPx, heightPx)
-                    },
-                    maximumSize = this
-                )
-            )
-            _previewScale.value = 1f
-        }
+        previewScreenSize = event.size
     }
 
     private fun onSizeChanged(event: SizeChanged) {
@@ -998,9 +904,9 @@ class EditArtViewModel @Inject constructor(
     }
 
     private fun updateBitmap() {
+        _bitmap.value = null
         imageJob?.cancel()
         imageJob = viewModelScope.launch(imageProcessingDispatcher) {
-            _bitmap.value = null
             previewScreenSize?.let {
                 val newBitmap = visualizationUtils.createBitmap(
                     activities = activitiesFiltered,
@@ -1059,26 +965,6 @@ class EditArtViewModel @Inject constructor(
 
     private val filteredTypes: List<SportType>
         get() = _filterTypes.filter { it.second }.map { it.first }
-/*
-
-.takemutableListOf<SportType>().apply {
-/** [_filterTypes] must NOT be iterated over using an [Iterator] or a
- * [ConcurrentModificationException] will occur when rapidly toggling a filter type.
- *
- * Though it might seem this may cause an issue where the result of [filteredTypes]
- * does not reflect the UI, it does not seem to by manual test.
- *
- * If it does cause issue, an alternative solution is to move access of this
- * variable into the [activitiesProcessingDispatcher] thread - or just remove that thread. **/
-for (i in 0.._filterTypes.lastIndex) {
-    _filterTypes
-        .getOrNull(i)
-        ?.takeIf { it.second }
-        ?.let { add(it.first) }
-}
-
- */
-
 
     private val filteredDistanceRangeMeters: IntRange
         get() = (_filterDistanceSelectedStart.value

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/EditArtViewModel.kt
@@ -5,6 +5,7 @@ import android.util.Size
 import androidx.compose.runtime.*
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.unit.Velocity
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.activityartapp.architecture.BaseRoutingViewModel
@@ -246,6 +247,7 @@ class EditArtViewModel @Inject constructor(
     private val _bitmap = mutableStateOf<Bitmap?>(null) // not save
     private val _previewOffset = mutableStateOf(Offset.Zero)
     private val _previewScale = mutableStateOf(1f)
+    private val _previewVelocity = mutableStateOf(Velocity(0f, 0f))
 
     // FILTERS
     private val _filterActivitiesCountDate = mutableStateOf(0)
@@ -330,8 +332,6 @@ class EditArtViewModel @Inject constructor(
                 filterDistancePendingChangeStart = _filterDistancePendingChangeStart,
                 filterDistancePendingChangeEnd = _filterDistancePendingChangeEnd,
                 filterTypes = _filterTypes,
-                previewOffset = _previewOffset,
-                previewScale = _previewScale,
                 sizeResolutionList = _sizeResolutionList,
                 sizeResolutionListSelectedIndex = _sizeResolutionListSelectedIndex,
                 sortDirectionTypeSelected = _sortDirectionTypeSelected,
@@ -609,11 +609,13 @@ class EditArtViewModel @Inject constructor(
 
             /* Adjust offset within maximum range */
             val newOffset = scaledRequestedOffset.run {
-                copy(x = x.coerceIn(offsetRangeX), y = y.coerceIn(offsetRangeY))
+
+                   copy(x = x, y = y.coerceIn(offsetRangeY))
             } + offsetToCenter
 
             _previewOffset.value = newOffset
             velocityTracker.addPosition(System.currentTimeMillis(), newOffset)
+            _previewVelocity.value = velocityTracker.calculateVelocity()
         }
     }
 
@@ -651,7 +653,8 @@ class EditArtViewModel @Inject constructor(
 
             /* Adjust offset within maximum range */
             val newOffset = scaledRequestedOffset.run {
-                copy(x = x.coerceIn(offsetRangeX), y = y.coerceIn(offsetRangeY))
+                copy()
+                copy(x = x, y = y.coerceIn(offsetRangeY))
             } + offsetToCenter
 
             _previewOffset.value = newOffset

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/CustomDetection.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/CustomDetection.kt
@@ -12,7 +12,8 @@ import androidx.compose.ui.util.fastForEach
 
 suspend fun PointerInputScope.detectZoomPanGesture(
     onZoom: (centroid: Offset, pan: Offset, zoom: Float) -> Unit,
-    onPan: (pan: Offset, pressed: Boolean) -> Unit
+    onPan: (pan: Offset) -> Unit,
+    onRelease: () -> Unit
 ) {
     forEachGesture {
         awaitPointerEventScope {
@@ -24,8 +25,6 @@ suspend fun PointerInputScope.detectZoomPanGesture(
             val down = awaitFirstDown(requireUnconsumed = false)
             do {
                 val event = awaitPointerEvent()
-                val wasNotReleased = event.changes.fastAny { it.id == down.id }
-                println("here  $wasNotReleased was not released")
                 val canceled = event.changes.fastAny { it.isConsumed }
                 if (!canceled) {
                     val zoomChange = event.calculateZoom()
@@ -51,7 +50,7 @@ suspend fun PointerInputScope.detectZoomPanGesture(
                         if (zoomChange != 1f) {
                             onZoom(centroid, panChange, zoomChange)
                         } else if (panChange != Offset.Zero) {
-                            onPan(panChange, event.changes.fastAny { it.id == down.id })
+                            onPan(panChange)
                         }
                         event.changes.fastForEach {
                             if (it.positionChanged()) {
@@ -60,8 +59,8 @@ suspend fun PointerInputScope.detectZoomPanGesture(
                         }
                     }
                 }
-            } while (!canceled && event.changes.fastAny { it.pressed }.also {
-                println("all was pressed? $it")
+            } while ((!canceled && event.changes.fastAny { it.pressed }).also {
+                    if (!it) onRelease()
                 })
         }
     }

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/CustomDetection.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/CustomDetection.kt
@@ -22,7 +22,7 @@ suspend fun PointerInputScope.detectZoomPanGesture(
             var pastTouchSlop = false
             val touchSlop = viewConfiguration.touchSlop
 
-            val down = awaitFirstDown(requireUnconsumed = false)
+            awaitFirstDown(requireUnconsumed = false)
             do {
                 val event = awaitPointerEvent()
                 val canceled = event.changes.fastAny { it.isConsumed }

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
@@ -1,15 +1,17 @@
 package com.activityartapp.presentation.editArtScreen.subscreens.preview
 
 import android.graphics.Bitmap
+import android.util.Size
+import androidx.compose.animation.core.*
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -17,21 +19,26 @@ import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Velocity
 import com.activityartapp.R
 import com.activityartapp.architecture.EventReceiver
 import com.activityartapp.presentation.common.ErrorComposable
 import com.activityartapp.presentation.common.ScreenBackground
 import com.activityartapp.presentation.editArtScreen.EditArtViewEvent
+import kotlinx.coroutines.launch
 
 @Composable
 fun EditArtPreview(
     atLeastOneActivitySelected: State<Boolean>,
     backgroundIsTransparent: State<Boolean>,
     bitmap: State<Bitmap?>,
-    offset: State<Offset>,
-    scale: State<Float>,
+    //  offset: State<Offset>,
+    //   scale: State<Float>,
+    //  velocity: State<Velocity>,
     eventReceiver: EventReceiver<EditArtViewEvent>
 ) {
     if (!atLeastOneActivitySelected.value) {
@@ -44,33 +51,152 @@ fun EditArtPreview(
         }
     } else {
         bitmap.value?.let {
-            Box(
+            BoxWithConstraints(
                 modifier = Modifier
                     .fillMaxSize()
-                    .pointerInput(Unit) {
-                        detectZoomPanGesture(
-                            { centroid, pan, zoom ->
-                                eventReceiver.onEvent(EditArtViewEvent.PreviewGestureZoom(
-                                    centroid,
-                                    pan,
-                                    zoom
-                                ))
-                            },
-                            { pan, released ->
-                                eventReceiver.onEvent(EditArtViewEvent.PreviewGestureDrag(
-                                   pan,
-                                   !released
-                                ))
-                            }
+            ) {
+                val localDensity = LocalDensity.current
+                val scale = remember { mutableStateOf(1f) }
+                val velocityDecay: DecayAnimationSpec<Float> = exponentialDecay()
+                val velocityTracker: VelocityTracker = VelocityTracker()
+
+                val computeScaledExcess: () -> Offset = {
+                    val scaledBitmapWidth = it.width * scale.value
+                    val scaledBitmapHeight = it.height * scale.value
+                    Offset(
+                        x = scaledBitmapWidth - localDensity.run { maxWidth.toPx() },
+                        y = scaledBitmapHeight - localDensity.run { maxHeight.toPx() }
+                    )
+                }
+
+                val centerFromScaledExcess: () -> Offset = {
+                    (computeScaledExcess() / 2f).run {
+                        copy(
+                            x = x.coerceAtMost(maximumValue = 0f),
+                            y = y.coerceAtMost(maximumValue = 0f)
                         )
                     }
-            ) {
+                }
+
+                val animatableOffsetX = remember {
+                    Animatable(initialValue = centerFromScaledExcess().x)
+                }
+                val animatableOffsetY = remember {
+                    Animatable(initialValue = centerFromScaledExcess().y)
+                }
+
+                val scope = rememberCoroutineScope()
+
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
+                        .pointerInput(Unit) {
+                            detectZoomPanGesture(
+                                onZoom = { centroid, pan, zoom ->
+                                    val oldScale = scale.value
+                                    scale.value = (oldScale * zoom).coerceIn(1f..5f)
+
+                                    /* Compute a new offset which would perfectly center the image within the user's
+                                    fingers; may be out-of-bounds. */
+                                    val scaledPrevOffset = Offset(
+                                        animatableOffsetX.value,
+                                        animatableOffsetY.value
+                                    ) / oldScale
+                                    val scaledPrevCent = centroid / oldScale
+                                    val scaledPrevPan = pan / oldScale
+                                    val scaledNewCent = centroid / scale.value
+                                    val requestedOffset =
+                                        scaledPrevOffset + scaledPrevCent - scaledNewCent + scaledPrevPan
+                                    val scaledRequestedOffset = requestedOffset * scale.value
+
+                                    /* Compute the float range which the new offset must be coerced within */
+                                    val scaledExcess = computeScaledExcess()
+
+                                    /* Adjust offset within maximum range */
+                                    val newOffset = scaledRequestedOffset// + offsetToCenter
+
+                                    val halfX = (scaledExcess.x / 2f).coerceAtMost(0f)
+                                    if (scaledExcess.x >= 0f) {
+                                        animatableOffsetX.updateBounds(
+                                            lowerBound = 0f,
+                                            upperBound = scaledExcess.x
+                                        )
+                                    } else {
+                                        animatableOffsetX.updateBounds(
+                                            lowerBound = halfX,
+                                            upperBound = halfX
+                                        )
+                                    }
+                                    val halfY = (scaledExcess.y / 2f).coerceAtMost(0f)
+                                    if (scaledExcess.y >= 0f) {
+                                        animatableOffsetY.updateBounds(
+                                            lowerBound = 0f,
+                                            upperBound = scaledExcess.y
+                                        )
+                                    } else {
+                                        animatableOffsetY.updateBounds(
+                                            lowerBound = halfY,
+                                            upperBound = halfY
+                                        )
+                                    }
+                                    velocityTracker.resetTracking()
+
+                                    scope.launch {
+                                        animatableOffsetX.snapTo(targetValue = newOffset.x)
+                                        animatableOffsetY.snapTo(targetValue = newOffset.y)
+                                    }
+                                },
+                                onPan = { pan ->
+                                    /* Compute the float range which the new offset must be coerced within */
+                                    val scaledExcess = computeScaledExcess()
+                                    val offsetToCenter = Offset(
+                                        scaledExcess.x
+                                            .div(2f)
+                                            .coerceAtMost(0f),
+                                        scaledExcess.y
+                                            .div(2f)
+                                            .coerceAtMost(0f)
+                                    )
+
+                                    val maxOffsetX: Float =
+                                        scaledExcess.x.coerceAtLeast(minimumValue = 0f)
+                                    val maxOffsetY: Float =
+                                        scaledExcess.y.coerceAtLeast(minimumValue = 0f)
+
+                                    /* Adjust offset within maximum range */
+                                    val newOffsetX = animatableOffsetX.value - pan.x
+                                    val newOffsetY = animatableOffsetY.value - pan.y
+
+
+                                    println("new offset is $newOffsetX plus offset to center ${offsetToCenter.x}")
+                                    velocityTracker.addPosition(
+                                        System.currentTimeMillis(),
+                                        Offset(newOffsetX, newOffsetY)
+                                    )
+                                    println("velocity tracker added position...")
+                                    val velocity = velocityTracker.calculateVelocity()
+                                    println("velocity was $velocity")
+                                    scope.launch {
+                                        animatableOffsetX.snapTo(newOffsetX)
+                                        animatableOffsetY.snapTo(newOffsetY)
+                                    }
+                                },
+                                onRelease = {
+                                    val velocity = velocityTracker.calculateVelocity()
+                                    velocityTracker.resetTracking()
+
+                                    scope.launch {
+                                        animatableOffsetX.animateDecay(velocity.x, velocityDecay)
+                                    }
+                                    scope.launch {
+                                        animatableOffsetY.animateDecay(velocity.y, velocityDecay)
+                                    }
+                                }
+                            )
+                        }
                         .graphicsLayer {
-                            translationX = -offset.value.x
-                            translationY = -offset.value.y
+                            translationX = -animatableOffsetX.value
+                            translationY = -animatableOffsetY.value
                             scaleX = scale.value
                             scaleY = scale.value
                             transformOrigin = TransformOrigin(0f, 0f)

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/preview/EditArtPreviewScreen.kt
@@ -61,8 +61,10 @@ fun EditArtPreview(
                 val velocityTracker = VelocityTracker()
 
                 val computeScaledExcess: () -> Offset = {
-                    val scaledBitmapWidth = localDensity.run { adjustedWidthDp.value.toPx() } * scale.value
-                    val scaledBitmapHeight = localDensity.run { adjustedHeightDp.value.toPx() } * scale.value
+                    val scaledBitmapWidth =
+                        localDensity.run { adjustedWidthDp.value.toPx() } * scale.value
+                    val scaledBitmapHeight =
+                        localDensity.run { adjustedHeightDp.value.toPx() } * scale.value
                     Offset(
                         x = scaledBitmapWidth - localDensity.run { maxWidth.toPx() },
                         y = scaledBitmapHeight - localDensity.run { maxHeight.toPx() }
@@ -78,9 +80,8 @@ fun EditArtPreview(
                     }
                 }
 
-                val animatableOffsetX = remember {
-                    Animatable(initialValue = centerFromScaledExcess().x)
-                }
+                val animatableOffsetX =
+                    remember { Animatable(initialValue = centerFromScaledExcess().x) }
                 val animatableOffsetY = remember {
                     Animatable(initialValue = centerFromScaledExcess().y)
                 }


### PR DESCRIPTION
* This commit adds a fling to the zoom-in.
* Increases the maximum zoom-in to 5x.
* The code is a little messy and should be refactored in the future to minimize recomposition, but is otherwise fully functional as it should be.