### PR TITLE
Add night mode when system is in night mode

### DIFF
--- a/app/src/main/java/com/activityartapp/presentation/MainActivity.kt
+++ b/app/src/main/java/com/activityartapp/presentation/MainActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/filters/sections/SectionDistances.kt
+++ b/app/src/main/java/com/activityartapp/presentation/editArtScreen/subscreens/filters/sections/SectionDistances.kt
@@ -124,7 +124,6 @@ fun SectionDistances(
     FilterCount(count)
 }
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun RowScope.DistanceTextField(
     textFieldValue: String,
@@ -133,32 +132,27 @@ private fun RowScope.DistanceTextField(
     onValueChanged: (String) -> Unit
 ) {
     val interactionSource = remember { MutableInteractionSource() }
-    BasicTextField(
+    val focusManager = LocalFocusManager.current
+    OutlinedTextField(
         value = textFieldValue,
         onValueChange = onValueChanged,
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Decimal,
             imeAction = ImeAction.Done
         ),
-        modifier = Modifier.weight(1f, true),
-        keyboardActions = KeyboardActions(onDone = { onDone() }),
-        interactionSource = interactionSource,
-        decorationBox = {
-            TextFieldDefaults.OutlinedTextFieldDecorationBox(
-                value = textFieldValue,
-                visualTransformation = VisualTransformation.None,
-                innerTextField = it,
-                singleLine = true,
-                enabled = true,
-                label = {
-                    Text(
-                        text = labelString,
-                        style = MaterialTheme.typography.overline
-                    )
-                },
-                interactionSource = interactionSource,
+        modifier = Modifier.weight(weight = 1f, fill = true),
+        keyboardActions = KeyboardActions(onDone = {
+            onDone()
+            focusManager.clearFocus()
+        }),
+        label = {
+            Text(
+                text = labelString,
+                style = MaterialTheme.typography.overline
             )
-        }
+        },
+        singleLine = true,
+        interactionSource = interactionSource,
     )
 }
 

--- a/app/src/main/java/com/activityartapp/presentation/ui/theme/Theme.kt
+++ b/app/src/main/java/com/activityartapp/presentation/ui/theme/Theme.kt
@@ -1,7 +1,9 @@
 package com.activityartapp.presentation.ui.theme
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Typography
+import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -13,21 +15,41 @@ import androidx.compose.ui.text.font.FontWeight
 import com.activityartapp.R
 
 @Composable
-fun AthleteApiArtTheme(content: @Composable () -> Unit) {
-    val colors = lightColors(
-        primary = colorResource(R.color.primary_color),
-        primaryVariant = colorResource(R.color.primary_dark_color),
-        secondary = colorResource(R.color.secondary_color),
-        secondaryVariant = colorResource(R.color.primary_dark_color),
-        background = colorResource(R.color.background_color),
-        surface = colorResource(R.color.surface_color),
-        error = colorResource(R.color.error_color),
-        onPrimary = colorResource(R.color.on_primary_color),
-        onSecondary = colorResource(R.color.on_secondary_color),
-        onBackground = colorResource(R.color.on_background_color),
-        onSurface = colorResource(R.color.on_surface_color),
-        onError = colorResource(R.color.on_error_color),
-    )
+fun AthleteApiArtTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colors = if (darkTheme) {
+        darkColors(
+            primary = colorResource(R.color.primary_color_dark),
+            primaryVariant = colorResource(R.color.primary_dark_color_dark),
+            secondary = colorResource(R.color.secondary_color_dark),
+            secondaryVariant = colorResource(R.color.primary_dark_color_dark),
+            background = colorResource(R.color.background_color_dark),
+            surface = colorResource(R.color.surface_color_dark),
+            error = colorResource(R.color.error_color_dark),
+            onPrimary = colorResource(R.color.on_primary_color_dark),
+            onSecondary = colorResource(R.color.on_secondary_color_dark),
+            onBackground = colorResource(R.color.on_background_color_dark),
+            onSurface = colorResource(R.color.on_surface_color_dark),
+            onError = colorResource(R.color.on_error_color_dark),
+        )
+    } else {
+        lightColors(
+            primary = colorResource(R.color.primary_color),
+            primaryVariant = colorResource(R.color.primary_dark_color),
+            secondary = colorResource(R.color.secondary_color),
+            secondaryVariant = colorResource(R.color.primary_dark_color),
+            background = colorResource(R.color.background_color),
+            surface = colorResource(R.color.surface_color),
+            error = colorResource(R.color.error_color),
+            onPrimary = colorResource(R.color.on_primary_color),
+            onSecondary = colorResource(R.color.on_secondary_color),
+            onBackground = colorResource(R.color.on_background_color),
+            onSurface = colorResource(R.color.on_surface_color),
+            onError = colorResource(R.color.on_error_color),
+        )
+    }
 
     CompositionLocalProvider(
         LocalSpacing provides Spacing()

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,7 +1,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Theme.AthleteApiArt" parent="Theme.AppCompat">
-        <!-- Todo, remove this when implemented night theme -->
-        <item name="android:statusBarColor">@color/primary_dark_color</item>
     </style>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -16,4 +16,23 @@
     <color name="on_primary_color">#ffffffff</color>
     <color name="on_secondary_color">#ff000000</color>
     <color name="on_error_color">#ffffffff</color>
+
+    <color name="primary_color_dark">#ff7043</color>
+    <color name="primary_light_color_dark">#ffa270</color>
+    <color name="primary_dark_color_dark">#c63f17</color>
+    <color name="secondary_color_dark">#80d8ff</color>
+    <color name="secondary_light_color_dark">#b3e5fc</color>
+    <color name="secondary_dark_color_dark">#4ba3c7</color>
+    <color name="primary_text_color_dark">#ffffff</color>
+    <color name="secondary_text_color_dark">#b3b3b3</color>
+    <color name="background_color_dark">#212121</color>
+    <color name="surface_color_dark">#424242</color>
+    <color name="error_color_dark">#cf6679</color>
+    <color name="on_background_color_dark">#ffffff</color>
+    <color name="on_surface_color_dark">#ffffff</color>
+    <color name="on_primary_color_dark">#ffffff</color>
+    <color name="on_secondary_color_dark">#000000</color>
+    <color name="on_error_color_dark">#000000</color>
+
+
 </resources>


### PR DESCRIPTION
* This commit changes the application to a night mode dark theme when the system itself is in night mode but does not introduce a toggle within the app to do so.
* A bug was identified but not fixed in this commit when using the text field to update the longest value for filters distance which must be fixed.